### PR TITLE
feat(heartbeat): allow urgent kinds to bypass contact guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@ Engineering invariants:
 - macOS and Linux share one code path unless a demonstrated host boundary
   requires an adapter.
 
+Pull request conventions:
+
+- Name branches for the change, not the author, coding agent, or an internal
+  work item. Prefer purpose-based names such as `feat/<topic>`, `fix/<topic>`,
+  or `docs/<topic>`.
+- Use concise Conventional Commit-style PR titles (`type(scope): summary`),
+  for example `feat(heartbeat): allow urgent kinds to bypass contact guards`.
+- Keep public PR titles, descriptions, branch names, and commit messages
+  self-contained; do not expose internal ticket identifiers.
+
 Required verification:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Runtime core:** normalized events, append-only JSONL ledgers for events, audit, controls, and cadence, atomic JSON state writes, and POSIX `fcntl` file locks.
 - **Controls engine:** priority-based runtime control intents (`pause`, `resume`, `quota_save`, `play_next`) and manual/automatic cadence snoozing with distinct release rules.
 - **Heartbeat pipeline:** fail-closed execution order (`ControlGate → cadence → Judge → delivery/wake → terminal audit`), separating accepted, unverified, and verified effects.
+- **Heartbeat contact guards:** explicitly configured urgent kinds may bypass `recent_contact` and/or `active_chat`; defaults remain guarded, and candidates still pass through Judge and normal effect/receipt handling.
 - **Autonomy engine:** weighted single-choice provider selection, terminal failure handling per tick (no same-tick rerolls), and one-shot `play_next` consumption only after completed execution.
 - **Activity providers:** built-in `local_reflection`, opt-in `model_reflection` via Hermes auxiliary routing, and disabled host-fed `paper_browse` / `x_browse` read-only examples.
 - **Panel (Daily RAM):** typed values with source, confidence, TTL, daily epoch rollover at configurable anchor hour, sensor observations (`chat_rhythm`), consume-once lifecycles, and bounded autonomy afterglow pointers.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -49,6 +49,30 @@ fail-closed and auditable.
   `targeted_wake_adapter_unavailable`; it does not fall back to the current
   conversation. This is not a direct-message adapter.
 
+## Heartbeat contact guards
+
+`recent_contact` and `active_chat` remain enabled unless a heartbeat kind
+explicitly lists them in `bypass`. Naming a profile `urgent` does not enable a
+bypass by itself.
+
+```yaml
+heartbeat:
+  kinds:
+    urgent_signal:
+      enabled: true
+      profile: urgent
+      judge: required
+      host_only: true
+      bypass: [recent_contact, active_chat]
+```
+
+Urgent policies may select either contact guard independently. The existing
+`automatic_cooldown` and `manual_snooze` bypasses remain supported; unknown
+values are rejected. A bypass only lets the candidate continue to later Judge
+and policy evaluation. The bypass itself neither requests delivery or wake nor
+counts as an effect receipt; any later effect follows the normal receipt
+contract.
+
 Moonbite v0.1 does not expose a third-party provider discovery contract.
 Deployments register activity descriptors explicitly through a host adapter.
 The bundled registry contains `local_reflection`, opt-in `model_reflection`,

--- a/config/schema.json
+++ b/config/schema.json
@@ -177,7 +177,14 @@
         "host_only": {"type": "boolean", "default": true},
         "bypass": {
           "type": "array",
-          "items": {"enum": ["automatic_cooldown", "manual_snooze"]},
+          "items": {
+            "enum": [
+              "automatic_cooldown",
+              "manual_snooze",
+              "recent_contact",
+              "active_chat"
+            ]
+          },
           "uniqueItems": true,
           "default": []
         }

--- a/moonbite_plugin/config.py
+++ b/moonbite_plugin/config.py
@@ -20,7 +20,9 @@ _AUXILIARY_ALIAS = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _HEARTBEAT_KIND_NAME = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
 _HEARTBEAT_PROFILES = frozenset({"routine", "daily_anchor", "urgent", "maintenance"})
 _HEARTBEAT_JUDGES = frozenset({"required", "skip"})
-_HEARTBEAT_BYPASSES = frozenset({"automatic_cooldown", "manual_snooze"})
+_HEARTBEAT_BYPASSES = frozenset(
+    {"automatic_cooldown", "manual_snooze", "recent_contact", "active_chat"}
+)
 _HEARTBEAT_KIND_DEFAULTS = {
     "enabled": False,
     "profile": "routine",

--- a/moonbite_plugin/heartbeat.py
+++ b/moonbite_plugin/heartbeat.py
@@ -53,7 +53,9 @@ DEFAULT_MANUAL_COOLDOWN = timedelta(hours=1)
 DEFAULT_RECENT_CONTACT_WINDOW = timedelta(minutes=30)
 DEFAULT_EFFECT_TTL = timedelta(hours=1)
 DEFAULT_ANCHOR_HOUR = 6
-HEARTBEAT_BYPASSES = frozenset({"automatic_cooldown", "manual_snooze"})
+HEARTBEAT_BYPASSES = frozenset(
+    {"automatic_cooldown", "manual_snooze", "recent_contact", "active_chat"}
+)
 HEARTBEAT_PROFILES = frozenset({"routine", "daily_anchor", "urgent", "maintenance"})
 HEARTBEAT_JUDGE_TERMINALS = frozenset(
     {"approved", "denied", "failed", "maintenance", "unknown"}
@@ -3651,22 +3653,25 @@ class HeartbeatEngine:
                     code=HeartbeatReasonCode.COOLDOWN,
                     next_judge_at=until or next_due,
                 )
-            contact, _at = self._contact(candidate, now)
-            if contact is not None:
-                return self._result(
-                    "skipped",
-                    contact,
-                    candidate_id,
-                    gate,
-                    code=HeartbeatReasonCode.RECENT_CONTACT,
-                    next_judge_at=now
-                    + getattr(
-                        self.cadence,
-                        "recent_contact_window",
-                        DEFAULT_RECENT_CONTACT_WINDOW,
-                    ),
-                )
-            if self._active_chat(candidate, active_chat):
+            if "recent_contact" not in policy.bypass:
+                contact, _at = self._contact(candidate, now)
+                if contact is not None:
+                    return self._result(
+                        "skipped",
+                        contact,
+                        candidate_id,
+                        gate,
+                        code=HeartbeatReasonCode.RECENT_CONTACT,
+                        next_judge_at=now
+                        + getattr(
+                            self.cadence,
+                            "recent_contact_window",
+                            DEFAULT_RECENT_CONTACT_WINDOW,
+                        ),
+                    )
+            if "active_chat" not in policy.bypass and self._active_chat(
+                candidate, active_chat
+            ):
                 return self._result(
                     "skipped",
                     "active_chat",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,9 +102,17 @@ def test_custom_heartbeat_kind_is_normalized_with_safe_defaults():
         ("urgent", [], "required", True),
         ("urgent", ["automatic_cooldown"], "required", True),
         ("urgent", ["manual_snooze"], "required", True),
+        ("urgent", ["recent_contact"], "required", True),
+        ("urgent", ["active_chat"], "required", True),
+        ("urgent", ["recent_contact", "active_chat"], "required", True),
         (
             "urgent",
-            ["automatic_cooldown", "manual_snooze"],
+            [
+                "automatic_cooldown",
+                "manual_snooze",
+                "recent_contact",
+                "active_chat",
+            ],
             "required",
             True,
         ),
@@ -115,20 +123,23 @@ def test_custom_heartbeat_kind_is_normalized_with_safe_defaults():
 def test_heartbeat_kind_profile_boundaries_are_accepted(
     profile, bypass, judge, host_only
 ):
-    config = normalize_config(
-        {
-            "heartbeat": {
-                "kinds": {
-                    "custom_kind": {
-                        "profile": profile,
-                        "bypass": bypass,
-                        "judge": judge,
-                        "host_only": host_only,
-                    }
+    raw = {
+        "heartbeat": {
+            "kinds": {
+                "custom_kind": {
+                    "profile": profile,
+                    "bypass": bypass,
+                    "judge": judge,
+                    "host_only": host_only,
                 }
             }
         }
-    )
+    }
+    schema_path = Path(__file__).parents[1] / "config" / "schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    assert list(Draft202012Validator(schema).iter_errors(raw)) == []
+    config = normalize_config(raw)
     assert config["heartbeat"]["kinds"]["custom_kind"] == {
         "enabled": False,
         "profile": profile,

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -447,6 +447,50 @@ def _policy(
     }
 
 
+@pytest.mark.parametrize(
+    "bypass,recent,active,expected_reason,expected_calls",
+    [
+        ([], True, False, "recent_private_inbound", 0),
+        ([], False, True, "active_chat", 0),
+        (["recent_contact"], True, False, "silent", 1),
+        (["active_chat"], False, True, "silent", 1),
+        (["recent_contact"], True, True, "active_chat", 0),
+        (["active_chat"], True, True, "recent_private_inbound", 0),
+        (["recent_contact", "active_chat"], True, True, "silent", 1),
+    ],
+)
+def test_contact_guard_bypass_is_explicit_and_policy_scoped(
+    tmp_path,
+    bypass,
+    recent,
+    active,
+    expected_reason,
+    expected_calls,
+):
+    judge = Judge(JudgeDecision(False, False, "silent"))
+    sink = Sink()
+    runtime, _controls, _bus, _cadence = engine(
+        tmp_path,
+        judge,
+        sink,
+        kind_policies={
+            "urgent_signal": _policy(
+                profile="urgent",
+                host_only=True,
+                bypass=bypass,
+            )
+        },
+    )
+    context = {"events": ["fixture"], "due": True, "active_chat": active}
+    if recent:
+        context["recent_private_inbound_at"] = NOW
+
+    result = runtime.run(HeartbeatCandidate("urgent_signal", context))
+
+    assert (result.reason, judge.calls) == (expected_reason, expected_calls)
+    assert sink.deliveries == sink.wakes == 0
+
+
 def test_daily_anchor_profile_owns_due_state_without_context_flags(tmp_path):
     judge = Judge(JudgeDecision(False, False, "anchor_seen"))
     runtime, _controls, _bus, cadence = engine(


### PR DESCRIPTION
## Summary

- allow explicitly configured urgent heartbeat kinds to bypass `recent_contact` and/or `active_chat`
- keep defaults unchanged; the `urgent` profile alone does not enable a bypass
- document the public configuration and continue rejecting unknown bypass values
- define purpose-based branch names and Conventional Commit-style PR titles for future contributions

## Safety

A bypass only advances the candidate to the existing Judge and policy flow. It does not request delivery or wake, and it is not an effect receipt; any later effect follows the existing receipt contract.

## Verification

- 651 tests passed
- Ruff check and format check passed
- compileall passed
- Hermes public contract passed (10 tools, 5 hooks)
- wheel and sdist builds passed
- current tree, reachable history, identity, and unpacked artifact privacy scans passed
