### PR TITLE
chore(release): prepare 0.1.0 alpha 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "17 9 * * *"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a1] - 2026-08-28
+
 ### Added
 
 - **Runtime core:** normalized events, append-only JSONL ledgers for events, audit, controls, and cadence, atomic JSON state writes, and POSIX `fcntl` file locks.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ owns models, tools, credentials, scheduling, and delivery.
 Moonbite is an experimental project. Its first priority is to communicate a
 design philosophy and explore how that philosophy might work in practice.
 
+[![CI](https://github.com/beniedev/moonbite/actions/workflows/ci.yml/badge.svg)](https://github.com/beniedev/moonbite/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python: 3.11–3.14](https://img.shields.io/badge/Python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)](pyproject.toml)
 [![Platform: Linux / WSL2 / macOS](https://img.shields.io/badge/Platform-Linux%20%7C%20WSL2%20%7C%20macOS-informational.svg)](COMPATIBILITY.md)
@@ -36,14 +37,15 @@ Supported in this preview:
 
 Not provided in this preview:
 
-- PyPI or other package distribution
+- Publication to PyPI or another package registry
 - A stable public Python API guarantee
 - Support for non-Hermes agent hosts or frameworks
 - Production support or long-term compatibility guarantees
 - An internal scheduler, credential store, network browser, or messaging channel
 
-No Moonbite package is published for this preview. Install from source through
-Hermes and pin an immutable commit SHA.
+Moonbite is not published to a package registry. Preview releases are
+source-only; install through Hermes from a GitHub release tag or pin an
+immutable commit SHA.
 
 ## Why long-running agents need Moonbite
 
@@ -195,9 +197,9 @@ See [docs/features/PANEL.md](docs/features/PANEL.md).
 ## Project status
 
 ```text
-Status: pre-alpha public source preview
+Status: 0.1.0 Alpha 1 public preview
 Supported host: Hermes Agent only
-Distribution: source install from pinned SHA
+Distribution: source-only GitHub prerelease
 Support: best effort
 API stability: not guaranteed
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,7 @@ Moonbite 不取代宿主 Agent。模型、工具、凭据、调度和消息投�
 Moonbite 是一项实验性作品：首要目标是传达设计理念，并探索这些理念在
 实践中的可能性。
 
+[![CI](https://github.com/beniedev/moonbite/actions/workflows/ci.yml/badge.svg)](https://github.com/beniedev/moonbite/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python: 3.11–3.14](https://img.shields.io/badge/Python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)](pyproject.toml)
 [![Platform: Linux / WSL2 / macOS](https://img.shields.io/badge/Platform-Linux%20%7C%20WSL2%20%7C%20macOS-informational.svg)](COMPATIBILITY.md)
@@ -36,14 +37,14 @@ Moonbite 是一项实验性作品：首要目标是传达设计理念，并探�
 
 本次预览不提供：
 
-- PyPI 或其他软件包分发
+- 发布到 PyPI 或其他软件包仓库
 - 稳定的公开 Python API 保证
 - 非 Hermes Agent 宿主框架支持
 - 生产支持或长期兼容性保证
 - 内置调度器、凭据存储、网络浏览器或消息渠道
 
-本次预览没有发布 Moonbite 软件包。请通过 Hermes 从源码安装，并锁定
-不可变的 Commit SHA。
+Moonbite 尚未发布到软件包仓库。预览版本仅以源码提供；请通过 Hermes
+使用 GitHub Release 标签安装，或锁定对应的不可变 Commit SHA。
 
 ## 为什么长期运行的 Agent 需要 Moonbite
 
@@ -185,9 +186,9 @@ API 保证。
 ## 项目状态
 
 ```text
-Status: pre-alpha public source preview
+Status: 0.1.0 Alpha 1 public preview
 Supported host: Hermes Agent only
-Distribution: source install from pinned SHA
+Distribution: source-only GitHub prerelease
 Support: best effort
 API stability: not guaranteed
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-Moonbite is a pre-alpha and has no supported stable release yet. Do not
+Moonbite is an alpha preview and has no supported stable release yet. Do not
 open a public issue containing credentials, private messages, personal memory,
 session identifiers, platform targets, coordinates, state files, or logs.
 Report a suspected vulnerability privately to the repository owner through

--- a/SETUP.md
+++ b/SETUP.md
@@ -5,8 +5,8 @@ persistent runtime plugin for [Hermes Agent](https://github.com/NousResearch/her
 as well as how to set up a local development and testing environment.
 
 > [!NOTE]
-> **Pre-alpha public source preview:**
-> No Moonbite package is published for this preview. Install from source through
+> **0.1.0 Alpha 1 source preview:**
+> Moonbite is not published to a package registry. Install from source through
 > Hermes, pin a full 40-character Git commit SHA, and validate within an isolated
 > `HERMES_HOME` before touching a live profile. Do not use floating `main` as a
 > stable target.
@@ -231,7 +231,7 @@ To revert configuration changes, restore the previous Moonbite entry, restart an
 long-running Hermes process, and run `hermes moonbite doctor`. To return to an
 earlier plugin revision, reinstall its reviewed full SHA with `--force --ref`,
 then repeat the same restart and diagnostic steps. Keep the previous SHA and
-configuration backup before each pre-alpha upgrade.
+configuration backup before each preview upgrade.
 
 ### 5.2 Disabling or removing the plugin
 

--- a/docs/INSTALL_FOR_AGENTS.md
+++ b/docs/INSTALL_FOR_AGENTS.md
@@ -136,7 +136,7 @@ hermes plugins install beniedev/moonbite \
   --no-enable
 ```
 
-No Moonbite package is published for this preview. Install from source through
+Moonbite is not published to a package registry. Install from source through
 Hermes, and do not substitute a floating branch or historical baseline for the
 owner-approved commit.
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -97,11 +97,11 @@ This checklist is an authoritative guide for repository owners preparing a publi
 ## 5. Tagging, Artifact Hashing & GitHub Release
 
 - [ ] **Tagging Release Commit:**
-  After explicit owner authorization, create an immutable signed tag for the
-  approved release commit. Replace both placeholders; do not execute these as
-  written:
+  After explicit owner authorization, create an immutable annotated tag for
+  the approved release commit. Replace both placeholders; do not execute these
+  as written:
   ```bash
-  git tag -s <version-tag> <approved-release-commit> -m "Release <version-tag>"
+  git tag -a <version-tag> <approved-release-commit> -m "Release <version-tag>"
   git push origin <version-tag>
   ```
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 manifest_version: 1
 name: moonbite
-version: 0.1.0.dev0
-description: "Persistent runtime primitives for long-running agents on Hermes Agent."
+version: 0.1.0a1
+description: "Memory, working state, heartbeat, and bounded autonomy for long-running AI agents."
 author: "Bénie Studio"
 kind: standalone
 provides_tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moonbite-plugin"
-version = "0.1.0.dev0"
-description = "A persistent runtime for long-running agents on Hermes Agent"
+version = "0.1.0a1"
+description = "Memory, working state, heartbeat, and bounded autonomy for long-running AI agents"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11,<3.15"
 authors = [{name = "Bénie Studio"}]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "moonbite-plugin"
-version = "0.1.0.dev0"
+version = "0.1.0a1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- prepare project metadata and documentation for the 0.1.0 Alpha 1 public preview
- add the CI badge and avoid duplicate push runs on pull-request branches
- use an annotated release tag while keeping distribution source-only

## Verification

- 651 tests passed
- Ruff check, format check, and compileall passed
- pinned compatibility contract passed at `987064caa4f8845f605ac7346fed5b72fddfb21c`
- current upstream compatibility contract passed at `baa344dee76993f0444c18fc59a69738ccb339d0`
- clean install and clean wheel checks passed for `0.1.0a1`
- current tree, reachable history, identity, wheel, and sdist privacy scans passed

## Release boundary

- GitHub prerelease only; no PyPI publication or production rollout
- the tag and release remain gated on final maintainer confirmation after CI passes
