### PR TITLE
fix(session): recover orphaned turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Session recovery:** `hermes moonbite session status` lists exact open turns, and `session repair` appends an idempotent `abandoned` terminal for the specified current turn without fabricating a successful model response.
+
+### Fixed
+
+- **Orphaned turns:** a new `pre_llm_call` safely supersedes an older turn whose `post_llm_call` was omitted, preserving append-only audit history while preventing the Conversation Gate from remaining permanently active.
+
+### Compatibility
+
+- Session ledgers may now contain additive `moon.session.turn_terminal.v1` rows. Moonbite `0.1.0a1` cannot read upgraded state; take a state snapshot before upgrading and retain the new reader or restore that snapshot when rolling back.
+
 ## [0.1.0a1] - 2026-08-28
 
 ### Added

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -18,16 +18,32 @@ or undocumented implementation fields.
 
 ## 1. Verified Surface & Lifecycle Hooks
 
-Moonbite registers exactly 10 tools, 15 CLI commands, 1 slash command (`/moon`), and 5 manifest hooks.
+Moonbite registers exactly 10 tools, 16 CLI commands, 1 slash command (`/moon`), and 5 manifest hooks.
 
-The 5 manifest hooks execute in strict `HOOK_ORDER`:
+The 5 manifest hooks are registered in strict `HOOK_ORDER`:
 1. `pre_gateway_dispatch`: Fires before message authorization, providing a pre-auth host context seam. Without an explicit typed host resolver, Moonbite treats this as a no-op and never reads or records unauthorized message content.
 2. `on_session_start`: Fires when a session initializes; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires immediately before model invocation; records lifecycle step and optionally attaches fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
-4. `post_llm_call`: Fires after model generation; records settled post-model lifecycle state.
+4. `post_llm_call`: Fires only for a non-empty, non-interrupted final response; records a completed post-model turn.
 5. `on_session_finalize`: Fires when a session finishes; records normalized session finalization.
 
 The outer manifest (`plugin.yaml`) retains `manifest_version: 1` and `kind: standalone` because the pinned Hermes installer accepts only v1 manifests.
+
+### Turn liveness contract
+
+Moonbite does not require `post_llm_call` to fire for every `pre_llm_call`.
+A later pre-model hook records the previous open turn as `abandoned` under the
+same mutation lock before opening its successor. Operators can inspect open
+turns with `hermes moonbite session status` and append the same non-success
+terminal with an exact-ID `session repair` command. Both paths preserve the
+append-only ledger and never manufacture a completed response.
+
+`settled_turn_ids` continues to contain completed turns only. An abandoned
+turn no longer holds the active-chat gate forever, but remains unsettled and
+cannot make a checkpoint eligible. The additive
+`moon.session.turn_terminal.v1` ledger row is not readable by Moonbite
+`0.1.0a1`; deployments must snapshot state before upgrading and must not point
+an older binary at upgraded state.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -136,10 +136,36 @@ Moonbite registers exactly 5 lifecycle hooks in Hermes (in actual `HOOK_ORDER`):
 1. `pre_gateway_dispatch`: Runs before message authorization; provides a pre-authorization host context seam. Without an explicit typed host resolver, it acts as a no-op and never reads or records unauthorized message content.
 2. `on_session_start`: Fires when a session starts; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires before an LLM call; records the lifecycle step and may attach fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
-4. `post_llm_call`: Fires after an LLM call; records the settled post-model lifecycle state.
+4. `post_llm_call`: Fires only when Hermes has a non-empty final response and the turn was not interrupted; records a completed post-model turn.
 5. `on_session_finalize`: Fires when a session finishes; records normalized session finalization.
 
-### 2.8 Enabling optional modules incrementally
+### 2.8 Recover an orphaned turn
+
+Hermes may omit `post_llm_call` for an interrupted or empty-final-response
+turn. Moonbite does not treat the missing callback as success. When the next
+`pre_llm_call` arrives for the same lifecycle, Moonbite first appends an
+`abandoned` terminal for the old turn, then opens the new turn.
+
+For a session that has no new traffic, inspect the exact current IDs before
+repairing it:
+
+```bash
+hermes moonbite session status
+hermes moonbite session repair \
+  --lifecycle-id "<lifecycle-id>" \
+  --turn-id "<open-turn-id>"
+```
+
+`session status` reports open turns; it cannot determine whether a turn is
+still running. The repair command uses both IDs as a compare-and-set guard and
+appends an `abandoned` terminal. It never writes a synthetic successful
+`post_llm_call`, never marks the turn settled, and is safe to repeat. Do not
+edit `session_lifecycle.jsonl` by hand.
+
+An abandoned terminal releases the active-chat liveness gate for that turn,
+but it does not satisfy checkpoint or successful-response requirements.
+
+### 2.9 Enabling optional modules incrementally
 
 Once the inert baseline is verified:
 1. Choose exactly one optional module (for example, `modules.panel: true`).
@@ -232,6 +258,12 @@ long-running Hermes process, and run `hermes moonbite doctor`. To return to an
 earlier plugin revision, reinstall its reviewed full SHA with `--force --ref`,
 then repeat the same restart and diagnostic steps. Keep the previous SHA and
 configuration backup before each preview upgrade.
+
+This change adds `moon.session.turn_terminal.v1` rows to the existing session
+lifecycle ledger. Moonbite `0.1.0a1` cannot read those rows. Take a state
+snapshot before upgrading, and do not run an older binary against state that
+contains the new terminal schema. A code rollback must either retain the new
+reader or restore the pre-upgrade state snapshot.
 
 ### 5.2 Disabling or removing the plugin
 

--- a/moonbite_plugin/conversation.py
+++ b/moonbite_plugin/conversation.py
@@ -1155,6 +1155,8 @@ class ConversationBridge:
         if session_snapshot is None:
             open_turn_id = None
             settled_turn_ids: tuple[str, ...] = ()
+            terminal_turn_ids: tuple[str, ...] = ()
+            abandoned_turn_ids: tuple[str, ...] = ()
             session_evidence = False
         else:
             raw_open_turn = session_snapshot.open_turn_id
@@ -1169,6 +1171,46 @@ class ConversationBridge:
             settled_turn_ids = tuple(
                 _reference(item, "turn_id") for item in raw_settled
             )
+            terminal_field_present = hasattr(session_snapshot, "terminal_turn_ids")
+            abandoned_field_present = hasattr(session_snapshot, "abandoned_turn_ids")
+            raw_terminal = getattr(session_snapshot, "terminal_turn_ids", ())
+            raw_abandoned = getattr(session_snapshot, "abandoned_turn_ids", ())
+            if not isinstance(raw_terminal, (tuple, list)):
+                raise StateError("session terminal_turn_ids are invalid")
+            if not isinstance(raw_abandoned, (tuple, list)):
+                raise StateError("session abandoned_turn_ids are invalid")
+            try:
+                terminal_turn_ids = tuple(
+                    _reference(item, "turn_id") for item in raw_terminal
+                )
+                abandoned_turn_ids = tuple(
+                    _reference(item, "turn_id") for item in raw_abandoned
+                )
+            except (TypeError, ValueError) as exc:
+                raise StateError("session terminal turn evidence is invalid") from exc
+            if len(terminal_turn_ids) != len(set(terminal_turn_ids)):
+                raise StateError("session terminal_turn_ids are duplicated")
+            if len(abandoned_turn_ids) != len(set(abandoned_turn_ids)):
+                raise StateError("session abandoned_turn_ids are duplicated")
+            terminal_set = set(terminal_turn_ids)
+            if terminal_field_present and not set(settled_turn_ids).issubset(
+                terminal_set
+            ):
+                raise StateError("session settled turns are missing terminal evidence")
+            if abandoned_field_present and not set(abandoned_turn_ids).issubset(
+                terminal_set
+            ):
+                raise StateError(
+                    "session abandoned turns are missing terminal evidence"
+                )
+            if (
+                terminal_field_present
+                and abandoned_field_present
+                and (set(settled_turn_ids) & set(abandoned_turn_ids))
+            ):
+                raise StateError("session turn has conflicting terminal outcomes")
+            if open_turn_id is not None and open_turn_id in terminal_set:
+                raise StateError("session open turn has terminal evidence")
             session_evidence = True
 
         dirty = cycle is not None and bool(cycle.dirty_event_ids)
@@ -1189,7 +1231,14 @@ class ConversationBridge:
         settled = (
             cycle is not None and cycle.last_settled_at is not None and not unsettled
         )
-        active_chat = open_turn_id is not None or unsettled
+        latest_terminal_turn_id = terminal_turn_ids[-1] if terminal_turn_ids else None
+        latest_terminal_is_abandoned = (
+            latest_terminal_turn_id is not None
+            and latest_terminal_turn_id in abandoned_turn_ids
+        )
+        active_chat = open_turn_id is not None or (
+            unsettled and not latest_terminal_is_abandoned
+        )
         quiet_until = (
             None
             if cycle is None or cycle.last_settled_at is None

--- a/moonbite_plugin/plugin.py
+++ b/moonbite_plugin/plugin.py
@@ -181,6 +181,19 @@ def _setup_cli(parser: argparse.ArgumentParser) -> None:
     commands.add_parser("status", help="Show effective runtime status")
     commands.add_parser("doctor", help="Validate configuration without model calls")
 
+    session = commands.add_parser(
+        "session", help="Inspect or repair session lifecycle turn ownership"
+    )
+    session_commands = session.add_subparsers(dest="session_command")
+    session_commands.add_parser(
+        "status", help="List exact identifiers for currently open turns"
+    )
+    repair = session_commands.add_parser(
+        "repair", help="Abandon one exact open turn as non-success"
+    )
+    repair.add_argument("--lifecycle-id", required=True)
+    repair.add_argument("--turn-id", required=True)
+
     control = commands.add_parser("control", help="Inspect or change runtime controls")
     control.add_argument("action", choices=("status", "pause", "resume", "quota_save"))
     control.add_argument(
@@ -289,6 +302,20 @@ def _cli_handler(
         result = runtime.status(include_private_paths=True)
     elif command == "doctor":
         result = doctor_report(raw_config, runtime=runtime)
+    elif command == "session":
+        if args.session_command == "status":
+            result = runtime.session_status()
+        elif args.session_command == "repair":
+            result = runtime.repair_session_turn(
+                args.lifecycle_id,
+                args.turn_id,
+            )
+        else:
+            print(
+                "usage: hermes moonbite session {status,repair "
+                "--lifecycle-id ID --turn-id ID}"
+            )
+            return 2
     elif command == "control":
         result = runtime.control(
             args.action,
@@ -373,7 +400,11 @@ def _cli_handler(
         )
     else:
         print(
-            "usage: hermes moonbite {status,doctor,control,event,heartbeat,autonomy,panel,memory-search,memory-recall,memory-resurface,memory-maintenance-propose,memory-maintenance-apply,memory-open,memory-add,diary-synthesize}"
+            "usage: hermes moonbite "
+            "{status,doctor,session,control,event,heartbeat,autonomy,panel,"
+            "memory-search,memory-recall,memory-resurface,"
+            "memory-maintenance-propose,memory-maintenance-apply,memory-open,"
+            "memory-add,diary-synthesize}"
         )
         return 2
     print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True, default=str))

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -671,6 +671,43 @@ class MoonbiteRuntime:
             )
         return result
 
+    def session_status(self) -> dict[str, Any]:
+        """Return exact identifiers for currently open session turns.
+
+        This deliberately reports ownership, not an orphan classification:
+        an open turn may still be making progress.
+        """
+
+        open_turns = [
+            {
+                "session_id": snapshot.session_id,
+                "lifecycle_id": snapshot.lifecycle_id,
+                "turn_id": snapshot.open_turn_id,
+            }
+            for snapshot in self.session_store.snapshots()
+            if snapshot.open_turn_id is not None
+        ]
+        return {"ok": True, "open_turns": open_turns}
+
+    def repair_session_turn(
+        self,
+        lifecycle_id: str,
+        turn_id: str,
+    ) -> dict[str, Any]:
+        """Abandon one exact open turn without claiming successful completion."""
+
+        receipt = self.session_store.abandon_open_turn(lifecycle_id, turn_id)
+        return {
+            "ok": True,
+            "status": ("already_repaired" if receipt.deduplicated else "repaired"),
+            "session_id": receipt.session_id,
+            "lifecycle_id": receipt.lifecycle_id,
+            "turn_id": receipt.turn_id,
+            "outcome": receipt.outcome,
+            "reason": receipt.reason,
+            "superseded_by_turn_id": receipt.superseded_by_turn_id,
+        }
+
     def control(
         self,
         action: str,

--- a/moonbite_plugin/session.py
+++ b/moonbite_plugin/session.py
@@ -17,6 +17,7 @@ from .runtime_core import (
     isoformat,
     new_id,
     parse_time,
+    utc_now,
 )
 
 SESSION_LIFECYCLE_SCHEMA = "moon.session.lifecycle.v1"
@@ -24,6 +25,10 @@ SESSION_SCHEMA = SESSION_LIFECYCLE_SCHEMA
 LIFECYCLE_SCHEMA = SESSION_LIFECYCLE_SCHEMA
 SCHEMA_VERSION = SESSION_LIFECYCLE_SCHEMA
 SESSION_LIFECYCLE_KIND = "hook"
+SESSION_TURN_TERMINAL_SCHEMA = "moon.session.turn_terminal.v1"
+SESSION_TURN_TERMINAL_KIND = "turn_terminal"
+TURN_TERMINAL_OUTCOMES = frozenset({"abandoned"})
+TURN_TERMINAL_REASONS = frozenset({"superseded_by_new_pre", "operator_repair"})
 
 HOOK_ORDER = (
     "pre_gateway_dispatch",
@@ -65,6 +70,20 @@ _ROW_FIELDS = frozenset(
         "supported_hooks",
         "hook",
         "settled",
+    }
+)
+_TERMINAL_ROW_FIELDS = frozenset(
+    {
+        "schema_version",
+        "kind",
+        "event_id",
+        "session_id",
+        "lifecycle_id",
+        "turn_id",
+        "outcome",
+        "reason",
+        "superseded_by_turn_id",
+        "observed_at",
     }
 )
 
@@ -154,6 +173,8 @@ class SessionLifecycleSnapshot:
     open_turn_id: str | None
     finalized: bool
     private_contact_count: int
+    terminal_turn_ids: tuple[str, ...] = ()
+    abandoned_turn_ids: tuple[str, ...] = ()
 
     schema_version: ClassVar[str] = SESSION_LIFECYCLE_SCHEMA
 
@@ -239,6 +260,87 @@ SessionLifecycleState = SessionLifecycleSnapshot
 
 
 @dataclass(frozen=True, slots=True)
+class SessionTurnTerminal:
+    """Immutable non-hook terminal evidence for one session turn."""
+
+    schema_version: str
+    event_id: str
+    session_id: str
+    lifecycle_id: str
+    turn_id: str
+    outcome: str
+    reason: str
+    superseded_by_turn_id: str | None
+    observed_at: datetime
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SESSION_TURN_TERMINAL_SCHEMA:
+            raise ValueError("unsupported turn terminal schema")
+        _reference(self.event_id, "event_id")
+        _reference(self.session_id, "session_id")
+        _reference(self.lifecycle_id, "lifecycle_id")
+        _reference(self.turn_id, "turn_id")
+        if self.outcome not in TURN_TERMINAL_OUTCOMES:
+            raise ValueError("unsupported turn terminal outcome")
+        if self.reason not in TURN_TERMINAL_REASONS:
+            raise ValueError("unsupported turn terminal reason")
+        if self.reason == "superseded_by_new_pre":
+            if self.superseded_by_turn_id is None:
+                raise ValueError("superseded terminal requires successor turn_id")
+            _reference(self.superseded_by_turn_id, "superseded_by_turn_id")
+            if self.superseded_by_turn_id == self.turn_id:
+                raise ValueError("turn cannot supersede itself")
+        elif self.superseded_by_turn_id is not None:
+            raise ValueError("operator repair cannot name a successor turn")
+        if not isinstance(self.observed_at, datetime):
+            raise TypeError("observed_at must be a datetime")
+        object.__setattr__(self, "observed_at", as_utc(self.observed_at))
+
+    def to_row(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": SESSION_TURN_TERMINAL_KIND,
+            "event_id": self.event_id,
+            "session_id": self.session_id,
+            "lifecycle_id": self.lifecycle_id,
+            "turn_id": self.turn_id,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "superseded_by_turn_id": self.superseded_by_turn_id,
+            "observed_at": isoformat(self.observed_at),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SessionTurnTerminalReceipt:
+    """Receipt returned after a turn terminal is appended or replayed."""
+
+    schema_version: str
+    event_id: str
+    session_id: str
+    lifecycle_id: str
+    turn_id: str
+    outcome: str
+    reason: str
+    superseded_by_turn_id: str | None
+    observed_at: datetime
+    deduplicated: bool
+    snapshot: SessionLifecycleSnapshot
+
+    @property
+    def already_repaired(self) -> bool:
+        return self.deduplicated
+
+    @property
+    def is_duplicate(self) -> bool:
+        return self.deduplicated
+
+    @property
+    def state(self) -> SessionLifecycleSnapshot:
+        return self.snapshot
+
+
+@dataclass(frozen=True, slots=True)
 class _Callback:
     context: SessionContext
     hook: str
@@ -262,8 +364,7 @@ class _Callback:
 
 @dataclass(slots=True)
 class _TurnState:
-    post_seen: bool = False
-    settled: bool = False
+    outcome: str | None = None
 
 
 @dataclass
@@ -277,6 +378,9 @@ class _LifecycleState:
     hooks: list[str] = field(default_factory=list)
     gates: set[str] = field(default_factory=set)
     turns: dict[str, _TurnState] = field(default_factory=dict)
+    terminals: dict[str, SessionTurnTerminal] = field(default_factory=dict)
+    terminal_turn_ids: list[str] = field(default_factory=list)
+    abandoned_turn_ids: list[str] = field(default_factory=list)
     current_turn_id: str | None = None
     settled_turn_ids: list[str] = field(default_factory=list)
     finalized: bool = False
@@ -291,6 +395,8 @@ def _snapshot(state: _LifecycleState) -> SessionLifecycleSnapshot:
         supported_hooks=state.supported_hooks,
         hooks=tuple(state.hooks),
         settled_turn_ids=tuple(state.settled_turn_ids),
+        terminal_turn_ids=tuple(state.terminal_turn_ids),
+        abandoned_turn_ids=tuple(state.abandoned_turn_ids),
         open_turn_id=state.current_turn_id,
         finalized=state.finalized,
         private_contact_count=state.private_contact_count,
@@ -439,16 +545,19 @@ class SessionLifecycleStore:
             turn_id = context.turn_id
             if turn_id is None:
                 raise SessionLifecycleError("post_llm_call requires turn_id")
+            turn = state.turns.get(turn_id)
+            if turn is not None and turn.outcome is not None:
+                raise SessionLifecycleError(
+                    f"turn is already terminal ({turn.outcome})"
+                )
             if state.current_turn_id != turn_id:
                 raise SessionLifecycleError(
                     "post_llm_call must match the current pre_llm_call turn"
                 )
-            turn = state.turns[turn_id]
-            if turn.settled:
-                raise SessionLifecycleError("turn is already settled")
-            turn.post_seen = True
+            assert turn is not None
             if callback.settled:
-                turn.settled = True
+                turn.outcome = "completed"
+                state.terminal_turn_ids.append(turn_id)
                 state.settled_turn_ids.append(turn_id)
                 state.current_turn_id = None
 
@@ -480,15 +589,11 @@ class SessionLifecycleStore:
         if "pre_llm_call" in supported and not state.turns:
             raise SessionLifecycleError("on_session_finalize requires pre_llm_call")
         if state.current_turn_id is not None or any(
-            not turn.settled for turn in state.turns.values()
+            turn.outcome is None for turn in state.turns.values()
         ):
             raise SessionLifecycleError(
-                "on_session_finalize requires all turns to be settled"
+                "on_session_finalize requires all turns to be terminal or settled"
             )
-        if "post_llm_call" in supported and not any(
-            turn.post_seen for turn in state.turns.values()
-        ):
-            raise SessionLifecycleError("on_session_finalize requires post_llm_call")
 
     @staticmethod
     def _callback_from_row(row: Mapping[str, Any]) -> _Callback:
@@ -554,20 +659,134 @@ class SessionLifecycleStore:
             event_id=event_id,
         )
 
+    @staticmethod
+    def _terminal_from_row(row: Mapping[str, Any]) -> SessionTurnTerminal:
+        if set(row) != _TERMINAL_ROW_FIELDS:
+            raise SessionLifecycleError("turn terminal row has invalid fields")
+        if row["schema_version"] != SESSION_TURN_TERMINAL_SCHEMA:
+            raise SessionLifecycleError("turn terminal row has an unsupported schema")
+        if row["kind"] != SESSION_TURN_TERMINAL_KIND:
+            raise SessionLifecycleError("turn terminal row has an unsupported kind")
+        if type(row["observed_at"]) is not str:
+            raise SessionLifecycleError("turn terminal observed_at is invalid")
+        if (
+            row["superseded_by_turn_id"] is not None
+            and type(row["superseded_by_turn_id"]) is not str
+        ):
+            raise SessionLifecycleError(
+                "turn terminal superseded_by_turn_id is invalid"
+            )
+        try:
+            return SessionTurnTerminal(
+                schema_version=row["schema_version"],
+                event_id=row["event_id"],
+                session_id=row["session_id"],
+                lifecycle_id=row["lifecycle_id"],
+                turn_id=row["turn_id"],
+                outcome=row["outcome"],
+                reason=row["reason"],
+                superseded_by_turn_id=row["superseded_by_turn_id"],
+                observed_at=parse_time(row["observed_at"]),
+            )
+        except (KeyError, TypeError, ValueError, StateError) as exc:
+            raise SessionLifecycleError("turn terminal row is invalid") from exc
+
+    @staticmethod
+    def _validate_state_identity(
+        state: _LifecycleState, context: SessionContext
+    ) -> None:
+        if context.lifecycle_id != state.lifecycle_id:
+            raise SessionLifecycleError("callback lifecycle_id does not match state")
+        if context.session_id != state.session_id:
+            raise SessionLifecycleError("session_id changed within a lifecycle")
+        if context.supported_hooks != state.supported_hooks:
+            raise SessionLifecycleError("supported_hooks changed within a lifecycle")
+
+    @staticmethod
+    def _validate_new_pre(state: _LifecycleState, callback: _Callback) -> None:
+        context = callback.context
+        if state.finalized:
+            raise SessionLifecycleError("session lifecycle is already finalized")
+        if callback.hook not in context.supported_hooks:
+            raise SessionLifecycleError(
+                f"hook {callback.hook!r} is not supported by this lifecycle"
+            )
+        turn_id = context.turn_id
+        if turn_id is None:
+            raise SessionLifecycleError("pre_llm_call requires turn_id")
+        if (
+            "pre_gateway_dispatch" in context.supported_hooks
+            and "pre_gateway_dispatch" not in state.gates
+        ):
+            raise SessionLifecycleError("pre_llm_call requires pre_gateway_dispatch")
+        if (
+            "on_session_start" in context.supported_hooks
+            and "on_session_start" not in state.gates
+        ):
+            raise SessionLifecycleError("pre_llm_call requires on_session_start")
+        if turn_id in state.turns:
+            raise SessionLifecycleError("turn_id was already used")
+
+    @staticmethod
+    def _apply_terminal(state: _LifecycleState, terminal: SessionTurnTerminal) -> None:
+        if terminal.lifecycle_id != state.lifecycle_id:
+            raise SessionLifecycleError("terminal lifecycle_id does not match state")
+        if terminal.session_id != state.session_id:
+            raise SessionLifecycleError(
+                "terminal session_id changed within a lifecycle"
+            )
+        if state.finalized:
+            raise SessionLifecycleError("session lifecycle is already finalized")
+        if terminal.turn_id in state.terminals:
+            raise SessionLifecycleError("turn already has a terminal")
+        turn = state.turns.get(terminal.turn_id)
+        if turn is None:
+            raise SessionLifecycleError("terminal references an unknown turn")
+        if turn.outcome is not None:
+            raise SessionLifecycleError(f"turn is already terminal ({turn.outcome})")
+        if state.current_turn_id != terminal.turn_id:
+            raise SessionLifecycleError(
+                "terminal must match the current pre_llm_call turn"
+            )
+        turn.outcome = terminal.outcome
+        state.terminals[terminal.turn_id] = terminal
+        state.terminal_turn_ids.append(terminal.turn_id)
+        if terminal.outcome == "abandoned":
+            state.abandoned_turn_ids.append(terminal.turn_id)
+        state.current_turn_id = None
+
     def _replay_unlocked(self) -> dict[str, _LifecycleState]:
         states: dict[str, _LifecycleState] = {}
         event_ids: set[str] = set()
         for row_number, row in enumerate(self.ledger.rows(), start=1):
             try:
-                callback = self._callback_from_row(row)
-                if callback.event_id in event_ids:
+                kind = row.get("kind")
+                if kind == SESSION_LIFECYCLE_KIND:
+                    callback = self._callback_from_row(row)
+                    event_id = callback.event_id
+                elif kind == SESSION_TURN_TERMINAL_KIND:
+                    terminal = self._terminal_from_row(row)
+                    event_id = terminal.event_id
+                else:
+                    raise SessionLifecycleError(
+                        "session lifecycle row has an unsupported kind"
+                    )
+                if event_id in event_ids:
                     raise SessionLifecycleError("duplicate session lifecycle event_id")
-                event_ids.add(callback.event_id)
-                state = states.get(callback.context.lifecycle_id)
-                if state is None:
-                    state = self._new_state(callback.context)
-                    states[callback.context.lifecycle_id] = state
-                self._apply(state, callback, allow_duplicate=False)
+                event_ids.add(event_id)
+                if kind == SESSION_LIFECYCLE_KIND:
+                    state = states.get(callback.context.lifecycle_id)
+                    if state is None:
+                        state = self._new_state(callback.context)
+                        states[callback.context.lifecycle_id] = state
+                    self._apply(state, callback, allow_duplicate=False)
+                else:
+                    state = states.get(terminal.lifecycle_id)
+                    if state is None:
+                        raise SessionLifecycleError(
+                            "turn terminal references an unknown lifecycle"
+                        )
+                    self._apply_terminal(state, terminal)
             except SessionLifecycleError as exc:
                 raise SessionLifecycleError(
                     f"session_lifecycle.jsonl row {row_number} is invalid"
@@ -594,6 +813,27 @@ class SessionLifecycleStore:
             snapshot=_snapshot(state),
         )
 
+    @staticmethod
+    def _terminal_receipt(
+        terminal: SessionTurnTerminal,
+        state: _LifecycleState,
+        *,
+        deduplicated: bool,
+    ) -> SessionTurnTerminalReceipt:
+        return SessionTurnTerminalReceipt(
+            schema_version=terminal.schema_version,
+            event_id=terminal.event_id,
+            session_id=terminal.session_id,
+            lifecycle_id=terminal.lifecycle_id,
+            turn_id=terminal.turn_id,
+            outcome=terminal.outcome,
+            reason=terminal.reason,
+            superseded_by_turn_id=terminal.superseded_by_turn_id,
+            observed_at=terminal.observed_at,
+            deduplicated=deduplicated,
+            snapshot=_snapshot(state),
+        )
+
     def record_hook(
         self,
         context: SessionContext,
@@ -616,15 +856,43 @@ class SessionLifecycleStore:
             if state is None:
                 state = self._new_state(context)
                 states[context.lifecycle_id] = state
-            deduplicated = self._apply(state, callback, allow_duplicate=True)
-            if deduplicated:
-                existing = state.callbacks[callback.key]
+            existing = state.callbacks.get(callback.key)
+            if existing is not None:
+                # Let the normal identity validator handle duplicate and
+                # conflicting callbacks before any recovery path runs.
+                self._apply(state, callback, allow_duplicate=True)
                 callback = existing
+                deduplicated = True
             else:
+                if hook == "pre_llm_call":
+                    # Validate the successor before closing the old turn. This
+                    # keeps rejected pre callbacks from mutating durable state.
+                    self._validate_state_identity(state, context)
+                    self._validate_new_pre(state, callback)
+                if hook == "pre_llm_call" and state.current_turn_id is not None:
+                    old_turn_id = state.current_turn_id
+                    assert old_turn_id is not None
+                    terminal = SessionTurnTerminal(
+                        schema_version=SESSION_TURN_TERMINAL_SCHEMA,
+                        event_id=new_id("session_turn_terminal"),
+                        session_id=state.session_id,
+                        lifecycle_id=state.lifecycle_id,
+                        turn_id=old_turn_id,
+                        outcome="abandoned",
+                        reason="superseded_by_new_pre",
+                        superseded_by_turn_id=context.turn_id,
+                        observed_at=context.observed_at,
+                    )
+                    self._apply_terminal(state, terminal)
+                    # If this append fails, the successor pre is not opened.
+                    # A later retry replays the durable terminal and proceeds.
+                    self.ledger.append(terminal.to_row())
                 # JsonlLedger propagates all write errors. State is rebuilt from
                 # disk on the next retry, so a failed append cannot leak a
                 # partially accepted callback into this store instance.
+                self._apply(state, callback, allow_duplicate=True)
                 self.ledger.append(callback.to_row())
+                deduplicated = False
             return self._receipt(
                 callback,
                 state,
@@ -636,6 +904,60 @@ class SessionLifecycleStore:
         with file_lock(self.mutation_lock):
             state = self._replay_unlocked().get(lifecycle_id)
             return None if state is None else _snapshot(state)
+
+    def abandon_open_turn(
+        self,
+        lifecycle_id: str,
+        turn_id: str,
+        observed_at: datetime | None = None,
+    ) -> SessionTurnTerminalReceipt:
+        """Append an exact operator repair for the current open turn.
+
+        This is a compare-and-set operation under the same mutation lock as
+        hook recording.  A previously abandoned turn is returned as-is,
+        while unknown, completed, or no-longer-current turns are rejected.
+        """
+
+        _reference(lifecycle_id, "lifecycle_id")
+        _reference(turn_id, "turn_id")
+        effective_observed_at = utc_now() if observed_at is None else observed_at
+        if not isinstance(effective_observed_at, datetime):
+            raise TypeError("observed_at must be a datetime")
+        effective_observed_at = as_utc(effective_observed_at)
+        with file_lock(self.mutation_lock):
+            state = self._replay_unlocked().get(lifecycle_id)
+            if state is None:
+                raise SessionLifecycleError("lifecycle_id was not found")
+            existing = state.terminals.get(turn_id)
+            if existing is not None:
+                if existing.outcome != "abandoned":
+                    raise SessionLifecycleError("turn is already terminal")
+                return self._terminal_receipt(existing, state, deduplicated=True)
+            turn = state.turns.get(turn_id)
+            if turn is None:
+                raise SessionLifecycleError("turn_id was not found")
+            if turn.outcome is not None:
+                raise SessionLifecycleError(
+                    f"turn is already terminal ({turn.outcome})"
+                )
+            if state.current_turn_id != turn_id:
+                raise SessionLifecycleError(
+                    "turn_id does not match the current open turn"
+                )
+            terminal = SessionTurnTerminal(
+                schema_version=SESSION_TURN_TERMINAL_SCHEMA,
+                event_id=new_id("session_turn_terminal"),
+                session_id=state.session_id,
+                lifecycle_id=state.lifecycle_id,
+                turn_id=turn_id,
+                outcome="abandoned",
+                reason="operator_repair",
+                superseded_by_turn_id=None,
+                observed_at=effective_observed_at,
+            )
+            self._apply_terminal(state, terminal)
+            self.ledger.append(terminal.to_row())
+            return self._terminal_receipt(terminal, state, deduplicated=False)
 
     def snapshots(self) -> tuple[SessionLifecycleSnapshot, ...]:
         with file_lock(self.mutation_lock):

--- a/scripts/check-hermes-contract.py
+++ b/scripts/check-hermes-contract.py
@@ -6,6 +6,7 @@ import argparse
 import inspect
 import json
 import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 import subprocess
 import sys
@@ -18,10 +19,77 @@ from hermes_cli.plugins import PluginContext
 from moonbite_plugin.config import normalize_config
 from moonbite_plugin.plugin import TOOL_NAMES
 from moonbite_plugin.session import HOOK_ORDER
+from moonbite_plugin.session import SessionContext, SessionLifecycleStore
 
 
 ROOT = Path(__file__).parents[1]
 PRESETS = ("core-only", "panel-only", "memory-only", "full-companion")
+
+
+def _session_context(
+    source_id: str,
+    *,
+    turn_id: str | None = None,
+    source_kind: str = "system",
+    observed_at: datetime,
+) -> SessionContext:
+    return SessionContext(
+        session_id="contract-session",
+        lifecycle_id="contract-session",
+        source_id=source_id,
+        turn_id=turn_id,
+        source_kind=source_kind,
+        observed_at=observed_at,
+        fresh=False,
+        supported_hooks=frozenset({"pre_llm_call", "post_llm_call"}),
+    )
+
+
+def _turn_exit_contract() -> None:
+    """Exercise host call sequences without depending on a Hermes checkout."""
+
+    now = datetime(2026, 8, 24, 19, 0, tzinfo=UTC)
+    with tempfile.TemporaryDirectory(prefix="moonbite-session-contract-") as root:
+        normal = SessionLifecycleStore(Path(root) / "normal")
+        normal.record_hook(
+            _session_context("pre-normal", turn_id="turn-normal", observed_at=now),
+            "pre_llm_call",
+        )
+        normal.record_hook(
+            _session_context(
+                "post-normal",
+                turn_id="turn-normal",
+                source_kind="assistant_response",
+                observed_at=now + timedelta(seconds=1),
+            ),
+            "post_llm_call",
+            settled=True,
+        )
+        assert normal.snapshot("contract-session").settled_turn_ids == ("turn-normal",)
+
+        for exit_reason in ("interrupted", "empty-final-response"):
+            store = SessionLifecycleStore(Path(root) / exit_reason)
+            store.record_hook(
+                _session_context(
+                    f"pre-{exit_reason}",
+                    turn_id="turn-abandoned",
+                    observed_at=now,
+                ),
+                "pre_llm_call",
+            )
+            # Hermes may omit post_llm_call for this host exit.  A successor
+            # pre must still recover the old ownership without a fake post.
+            successor = store.record_hook(
+                _session_context(
+                    f"pre-successor-{exit_reason}",
+                    turn_id="turn-successor",
+                    observed_at=now + timedelta(seconds=1),
+                ),
+                "pre_llm_call",
+            )
+            assert successor.snapshot.abandoned_turn_ids == ("turn-abandoned",)
+            assert successor.snapshot.open_turn_id == "turn-successor"
+            assert successor.snapshot.settled_turn_ids == ()
 
 
 def _metadata_contract() -> None:
@@ -159,6 +227,7 @@ def main() -> int:
     if args.loader_probe:
         _loader_probe()
         return 0
+    _turn_exit_contract()
     _metadata_contract()
     _loader_contract()
     print(

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -202,6 +202,128 @@ def test_schema_dirty_settled_and_non_private_receipts(tmp_path):
     assert settled.snapshot.active_chat is False
 
 
+def test_abandoned_turn_releases_active_gate_without_settling(tmp_path):
+    sessions, _effects, bridge = stores(tmp_path)
+    private_lifecycle(sessions, bridge)
+    sessions.abandon_open_turn(
+        "lifecycle-1",
+        "turn-1",
+        observed_at=NOW + timedelta(minutes=1),
+    )
+
+    snapshot = bridge.snapshot("lifecycle-1", now=NOW + timedelta(minutes=2))
+    assert snapshot.active_chat is False
+    assert snapshot.unsettled is True
+    assert snapshot.settled is False
+    assert snapshot.can_checkpoint is False
+    assert snapshot.blocked_reason == "unsettled"
+
+
+def test_abandoned_turn_releases_gate_when_dirty_event_has_no_turn_id(tmp_path):
+    sessions, _effects, bridge = stores(tmp_path)
+    gateway = sessions.record_hook(context("gateway"), "pre_gateway_dispatch")
+    bridge.observe(gateway)
+    start = sessions.record_hook(
+        context("start", source_kind="session_start"),
+        "on_session_start",
+    )
+    bridge.observe(start)
+    pre = sessions.record_hook(
+        context(
+            "pre",
+            source_kind="system",
+            turn_id="turn-1",
+            fresh=False,
+        ),
+        "pre_llm_call",
+    )
+    bridge.observe(pre)
+
+    sessions.abandon_open_turn(
+        "lifecycle-1",
+        "turn-1",
+        observed_at=NOW + timedelta(minutes=1),
+    )
+
+    snapshot = bridge.snapshot("lifecycle-1", now=NOW + timedelta(minutes=2))
+    assert snapshot.active_chat is False
+    assert snapshot.unsettled is True
+    assert snapshot.settled is False
+    assert snapshot.can_checkpoint is False
+    assert snapshot.blocked_reason == "unsettled"
+
+
+def test_successor_turn_stays_active_then_completes_normally(tmp_path):
+    sessions, _effects, bridge = stores(tmp_path)
+    private_lifecycle(sessions, bridge)
+    successor = sessions.record_hook(
+        context(
+            "private-2",
+            turn_id="turn-2",
+            observed_at=NOW + timedelta(minutes=1),
+        ),
+        "pre_llm_call",
+    )
+    active = bridge.observe(successor)
+    assert active.snapshot.active_chat is True
+    assert active.snapshot.open_turn_id == "turn-2"
+    assert active.snapshot.unsettled is True
+
+    completed = sessions.record_hook(
+        context(
+            "assistant-2",
+            source_kind="assistant_response",
+            turn_id="turn-2",
+            fresh=False,
+            observed_at=NOW + timedelta(minutes=2),
+        ),
+        "post_llm_call",
+        settled=True,
+    )
+    settled = bridge.observe(completed)
+    assert settled.snapshot.active_chat is False
+    assert settled.snapshot.settled is True
+
+
+def test_old_injected_session_snapshot_without_terminal_fields_fails_closed(
+    tmp_path, monkeypatch
+):
+    sessions, _effects, bridge = stores(tmp_path)
+    private_lifecycle(sessions, bridge)
+    monkeypatch.setattr(
+        bridge.session_store,
+        "snapshot",
+        lambda _lifecycle_id: SimpleNamespace(
+            session_id="session-1",
+            lifecycle_id="lifecycle-1",
+            open_turn_id=None,
+            settled_turn_ids=(),
+        ),
+    )
+    snapshot = bridge.snapshot("lifecycle-1")
+    assert snapshot.active_chat is True
+    assert snapshot.unsettled is True
+
+
+def test_invalid_terminal_snapshot_inclusion_is_rejected(tmp_path, monkeypatch):
+    sessions, _effects, bridge = stores(tmp_path)
+    private_lifecycle(sessions, bridge)
+    monkeypatch.setattr(
+        bridge.session_store,
+        "snapshot",
+        lambda _lifecycle_id: SimpleNamespace(
+            session_id="session-1",
+            lifecycle_id="lifecycle-1",
+            open_turn_id=None,
+            settled_turn_ids=(),
+            terminal_turn_ids=(),
+            abandoned_turn_ids=("turn-1",),
+        ),
+    )
+    with pytest.raises(StateError, match="missing terminal"):
+        bridge.snapshot("lifecycle-1")
+
+
 @pytest.mark.parametrize(
     "source_kind",
     ["session_start", "assistant_response", "system", "cron", "workroom", "tool"],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -782,6 +782,75 @@ def test_cli_parser_and_handler_round_trip(capsys, monkeypatch, tmp_path):
     assert json.loads(capsys.readouterr().out)["ok"] is True
 
 
+def test_session_status_and_exact_repair_cli(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    state_root = tmp_path / "state"
+    ctx = FakeContext({"state": {"directory": str(state_root)}})
+    register(ctx)
+    ctx.hooks["on_session_start"](session_id="session-cli")
+    ctx.hooks["pre_llm_call"](
+        session_id="session-cli",
+        turn_id="turn-cli",
+    )
+
+    parser = argparse.ArgumentParser()
+    ctx.cli["setup_fn"](parser)
+    assert ctx.cli["handler_fn"](parser.parse_args(["session", "status"])) == 0
+    status = json.loads(capsys.readouterr().out)
+    assert status == {
+        "ok": True,
+        "open_turns": [
+            {
+                "lifecycle_id": "session-cli",
+                "session_id": "session-cli",
+                "turn_id": "turn-cli",
+            }
+        ],
+    }
+
+    assert (
+        ctx.cli["handler_fn"](
+            parser.parse_args(
+                [
+                    "session",
+                    "repair",
+                    "--lifecycle-id",
+                    "session-cli",
+                    "--turn-id",
+                    "turn-cli",
+                ]
+            )
+        )
+        == 0
+    )
+    repaired = json.loads(capsys.readouterr().out)
+    assert repaired["ok"] is True
+    assert repaired["status"] == "repaired"
+    assert repaired["outcome"] == "abandoned"
+    assert repaired["reason"] == "operator_repair"
+    assert repaired["turn_id"] == "turn-cli"
+    assert "settled" not in repaired
+
+    assert (
+        ctx.cli["handler_fn"](
+            parser.parse_args(
+                [
+                    "session",
+                    "repair",
+                    "--lifecycle-id",
+                    "session-cli",
+                    "--turn-id",
+                    "turn-cli",
+                ]
+            )
+        )
+        == 0
+    )
+    already = json.loads(capsys.readouterr().out)
+    assert already["status"] == "already_repaired"
+    assert already["outcome"] == "abandoned"
+
+
 def test_cli_and_slash_doctor_receive_registered_runtime(capsys, monkeypatch, tmp_path):
     import moonbite_plugin.plugin as plugin_module
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,6 +11,7 @@ from moonbite_plugin.runtime_core import StateError
 from moonbite_plugin.session import (
     HOOK_ORDER,
     SESSION_LIFECYCLE_SCHEMA,
+    SESSION_TURN_TERMINAL_SCHEMA,
     SOURCE_KINDS,
     SessionContext,
     SessionLifecycleError,
@@ -19,6 +20,7 @@ from moonbite_plugin.session import (
 
 NOW = datetime(2026, 8, 24, 19, 0, tzinfo=UTC)
 ALL_HOOKS = frozenset(HOOK_ORDER)
+TURN_HOOKS = frozenset({"pre_llm_call", "post_llm_call"})
 
 
 def context(
@@ -336,6 +338,376 @@ def test_finalize_rejects_unsettled_turn(tmp_path) -> None:
             context("finalize", source_kind="system"), "on_session_finalize"
         )
     assert len(store.ledger.rows()) == 3
+
+
+def test_successor_pre_abandons_missing_post_without_settling(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(context("gateway"), "pre_gateway_dispatch")
+    store.record_hook(
+        context("start", source_kind="session_start"),
+        "on_session_start",
+    )
+    store.record_hook(context("pre-a", turn_id="turn-a"), "pre_llm_call")
+
+    successor = store.record_hook(
+        context(
+            "pre-b",
+            turn_id="turn-b",
+            observed_at=NOW + timedelta(minutes=1),
+        ),
+        "pre_llm_call",
+    )
+
+    assert successor.snapshot.open_turn_id == "turn-b"
+    assert successor.snapshot.settled_turn_ids == ()
+    assert successor.snapshot.terminal_turn_ids == ("turn-a",)
+    assert successor.snapshot.abandoned_turn_ids == ("turn-a",)
+    rows = store.ledger.rows()
+    terminal = rows[3]
+    assert terminal["schema_version"] == SESSION_TURN_TERMINAL_SCHEMA
+    assert terminal["kind"] == "turn_terminal"
+    assert terminal["outcome"] == "abandoned"
+    assert terminal["reason"] == "superseded_by_new_pre"
+    assert terminal["superseded_by_turn_id"] == "turn-b"
+
+    completed = store.record_hook(
+        context(
+            "post-b",
+            source_kind="assistant_response",
+            turn_id="turn-b",
+            fresh=False,
+            observed_at=NOW + timedelta(minutes=2),
+        ),
+        "post_llm_call",
+        settled=True,
+    )
+    assert completed.snapshot.open_turn_id is None
+    assert completed.snapshot.settled_turn_ids == ("turn-b",)
+    assert completed.snapshot.terminal_turn_ids == ("turn-a", "turn-b")
+
+
+def test_late_post_cannot_replace_abandoned_turn(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    store.record_hook(
+        context(
+            "pre-b",
+            turn_id="turn-b",
+            supported_hooks=TURN_HOOKS,
+            observed_at=NOW + timedelta(minutes=1),
+        ),
+        "pre_llm_call",
+    )
+    before = list(store.ledger.rows())
+
+    with pytest.raises(SessionLifecycleError, match="already terminal"):
+        store.record_hook(
+            context(
+                "post-a",
+                source_kind="assistant_response",
+                turn_id="turn-a",
+                fresh=False,
+                supported_hooks=TURN_HOOKS,
+                observed_at=NOW + timedelta(minutes=2),
+            ),
+            "post_llm_call",
+            settled=True,
+        )
+
+    assert store.ledger.rows() == before
+    assert store.snapshot("lifecycle-1").open_turn_id == "turn-b"
+
+
+def test_operator_repair_is_exact_non_success_and_idempotent(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+
+    first = store.abandon_open_turn(
+        "lifecycle-1",
+        "turn-a",
+        observed_at=NOW + timedelta(minutes=1),
+    )
+    second = store.abandon_open_turn(
+        "lifecycle-1",
+        "turn-a",
+        observed_at=NOW + timedelta(minutes=2),
+    )
+
+    assert first.deduplicated is False
+    assert second.deduplicated is True
+    assert second.reason == "operator_repair"
+    assert second.outcome == "abandoned"
+    assert second.snapshot.settled_turn_ids == ()
+    assert second.snapshot.open_turn_id is None
+    assert len(store.ledger.rows()) == 2
+
+    with pytest.raises(SessionLifecycleError, match="not found"):
+        store.abandon_open_turn("lifecycle-1", "unknown")
+
+
+def test_repair_compare_and_set_rejects_changed_or_completed_turn(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    store.record_hook(
+        context(
+            "post-a",
+            source_kind="assistant_response",
+            turn_id="turn-a",
+            fresh=False,
+            supported_hooks=TURN_HOOKS,
+            observed_at=NOW + timedelta(minutes=1),
+        ),
+        "post_llm_call",
+        settled=True,
+    )
+    store.record_hook(
+        context(
+            "pre-b",
+            turn_id="turn-b",
+            supported_hooks=TURN_HOOKS,
+            observed_at=NOW + timedelta(minutes=2),
+        ),
+        "pre_llm_call",
+    )
+    with pytest.raises(SessionLifecycleError, match="already terminal"):
+        store.abandon_open_turn("lifecycle-1", "turn-a")
+
+
+def test_finalize_accepts_completed_and_abandoned_terminal_mix(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(context("gateway"), "pre_gateway_dispatch")
+    store.record_hook(
+        context("start", source_kind="session_start"),
+        "on_session_start",
+    )
+    store.record_hook(context("pre-a", turn_id="turn-a"), "pre_llm_call")
+    store.record_hook(
+        context(
+            "post-a", source_kind="assistant_response", turn_id="turn-a", fresh=False
+        ),
+        "post_llm_call",
+        settled=True,
+    )
+    store.record_hook(
+        context(
+            "pre-b",
+            turn_id="turn-b",
+            observed_at=NOW + timedelta(minutes=1),
+        ),
+        "pre_llm_call",
+    )
+    store.abandon_open_turn(
+        "lifecycle-1",
+        "turn-b",
+        observed_at=NOW + timedelta(minutes=2),
+    )
+    finalized = store.record_hook(
+        context("finalize", source_kind="system", fresh=False),
+        "on_session_finalize",
+    )
+    assert finalized.snapshot.finalized is True
+    assert finalized.snapshot.settled_turn_ids == ("turn-a",)
+    assert finalized.snapshot.abandoned_turn_ids == ("turn-b",)
+
+
+def test_terminal_append_failure_does_not_open_successor(tmp_path, monkeypatch) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    original_append = store.ledger.append
+
+    def fail_terminal(row):
+        if row["kind"] == "turn_terminal":
+            raise OSError("terminal append fixture")
+        return original_append(row)
+
+    monkeypatch.setattr(store.ledger, "append", fail_terminal)
+    with pytest.raises(OSError, match="terminal append fixture"):
+        store.record_hook(
+            context(
+                "pre-b",
+                turn_id="turn-b",
+                supported_hooks=TURN_HOOKS,
+                observed_at=NOW + timedelta(minutes=1),
+            ),
+            "pre_llm_call",
+        )
+    assert store.ledger.rows()[0]["turn_id"] == "turn-a"
+    monkeypatch.setattr(store.ledger, "append", original_append)
+    assert (
+        store.record_hook(
+            context(
+                "pre-b",
+                turn_id="turn-b",
+                supported_hooks=TURN_HOOKS,
+                observed_at=NOW + timedelta(minutes=1),
+            ),
+            "pre_llm_call",
+        ).snapshot.open_turn_id
+        == "turn-b"
+    )
+
+
+def test_successor_append_failure_leaves_terminal_for_retry(
+    tmp_path, monkeypatch
+) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    original_append = store.ledger.append
+    failed = {"value": True}
+
+    def fail_successor(row):
+        if failed["value"] and row["kind"] == "hook" and row["turn_id"] == "turn-b":
+            failed["value"] = False
+            raise OSError("successor append fixture")
+        return original_append(row)
+
+    monkeypatch.setattr(store.ledger, "append", fail_successor)
+    with pytest.raises(OSError, match="successor append fixture"):
+        store.record_hook(
+            context(
+                "pre-b",
+                turn_id="turn-b",
+                supported_hooks=TURN_HOOKS,
+                observed_at=NOW + timedelta(minutes=1),
+            ),
+            "pre_llm_call",
+        )
+    assert [row["kind"] for row in store.ledger.rows()] == ["hook", "turn_terminal"]
+    monkeypatch.setattr(store.ledger, "append", original_append)
+    retry = store.record_hook(
+        context(
+            "pre-b",
+            turn_id="turn-b",
+            supported_hooks=TURN_HOOKS,
+            observed_at=NOW + timedelta(minutes=1),
+        ),
+        "pre_llm_call",
+    )
+    assert retry.deduplicated is False
+    assert retry.snapshot.abandoned_turn_ids == ("turn-a",)
+    assert len(store.ledger.rows()) == 3
+
+
+def test_mixed_ledger_replays_old_hook_rows_and_new_terminal_rows(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    repaired = store.abandon_open_turn("lifecycle-1", "turn-a", NOW)
+    assert repaired.deduplicated is False
+
+    reopened = SessionLifecycleStore(tmp_path)
+    snapshot = reopened.replay()[0]
+    assert snapshot.open_turn_id is None
+    assert snapshot.terminal_turn_ids == ("turn-a",)
+    assert snapshot.abandoned_turn_ids == ("turn-a",)
+    assert snapshot.settled_turn_ids == ()
+
+
+def test_concurrent_successors_and_repairs_have_one_terminal_per_turn(tmp_path) -> None:
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+
+    def successor(turn_id: str):
+        return store.record_hook(
+            context(
+                f"pre-{turn_id}",
+                turn_id=turn_id,
+                supported_hooks=TURN_HOOKS,
+            ),
+            "pre_llm_call",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        receipts = list(pool.map(successor, ("turn-b", "turn-c")))
+    assert all(receipt.snapshot.open_turn_id for receipt in receipts)
+    terminal_rows = [
+        row for row in store.ledger.rows() if row["kind"] == "turn_terminal"
+    ]
+    assert len(terminal_rows) == 2
+    assert len({row["turn_id"] for row in terminal_rows}) == 2
+    assert store.snapshot("lifecycle-1").open_turn_id in {"turn-b", "turn-c"}
+
+    duplicate_store = SessionLifecycleStore(tmp_path / "duplicate-successor")
+    duplicate_store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+
+    def duplicate_successor(_index: int):
+        return duplicate_store.record_hook(
+            context("pre-b", turn_id="turn-b", supported_hooks=TURN_HOOKS),
+            "pre_llm_call",
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        duplicate_receipts = list(pool.map(duplicate_successor, range(16)))
+    assert sum(not receipt.deduplicated for receipt in duplicate_receipts) == 1
+    assert duplicate_store.snapshot("lifecycle-1").open_turn_id == "turn-b"
+    assert [
+        row["turn_id"]
+        for row in duplicate_store.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ["turn-a"]
+
+    repair_store = SessionLifecycleStore(tmp_path / "repair")
+    repair_store.record_hook(
+        context("pre", turn_id="turn", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        repairs = list(
+            pool.map(
+                lambda _: repair_store.abandon_open_turn("lifecycle-1", "turn"),
+                range(16),
+            )
+        )
+    assert sum(not repair.deduplicated for repair in repairs) == 1
+    assert len(repair_store.ledger.rows()) == 2
+
+    race_store = SessionLifecycleStore(tmp_path / "repair-vs-pre")
+    race_store.record_hook(
+        context("pre-a", turn_id="turn-a", supported_hooks=TURN_HOOKS),
+        "pre_llm_call",
+    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        successor_future = pool.submit(
+            race_store.record_hook,
+            context("pre-b", turn_id="turn-b", supported_hooks=TURN_HOOKS),
+            "pre_llm_call",
+        )
+        repair_future = pool.submit(
+            race_store.abandon_open_turn,
+            "lifecycle-1",
+            "turn-a",
+        )
+        successor_future.result()
+        repair_future.result()
+    assert race_store.snapshot("lifecycle-1").open_turn_id == "turn-b"
+    assert [
+        row["turn_id"]
+        for row in race_store.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ["turn-a"]
 
 
 def test_append_failure_is_fail_closed_and_retryable(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- recover from a missing `post_llm_call` by append-only abandoning the prior open turn before accepting a successor `pre_llm_call`
- add exact, idempotent operator status and repair commands without recording a false successful completion
- release Conversation Gate liveness after abandonment while keeping checkpoint settlement fail-closed
- document lifecycle semantics, host behavior, compatibility, and downgrade requirements

## Validation
- full test suite: 666 passed
- Ruff lint and format checks passed
- pinned Hermes plugin doctor and lifecycle contract passed at `987064caa4f8845f605ac7346fed5b72fddfb21c`
- wheel and source distribution builds passed

Fixes #6
