### PR TITLE
feat: add scenario pack resolver foundation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,5 @@ include DESIGN.md
 include SECURITY.md
 include plugin.yaml
 recursive-include config *.json *.yaml
+recursive-include moonbite_plugin/scenario_packs *.json
 recursive-include docs *.md

--- a/docs/SCENARIO_PACKS.md
+++ b/docs/SCENARIO_PACKS.md
@@ -1,0 +1,49 @@
+# Scenario packs
+
+Moonbite resolves an optional data-only scenario pack before validating the
+existing behavior configuration. Hermes places the public selector beside the
+user configuration:
+
+```yaml
+plugins:
+  entries:
+    moonbite:
+      settings:
+        scenario_pack: null
+        config:
+          modules:
+            heartbeat: false
+```
+
+An omitted or `null` selector keeps the legacy `normalize_config` path exactly
+unchanged. A non-null selector must be a fixed catalog key matching
+`[a-z][a-z0-9-]{0,63}`; it is never treated as a filesystem path or URL.
+
+Pack resources are JSON files inside the installed
+`moonbite_plugin.scenario_packs` package. The catalog maps public names to
+fixed resource names and is intentionally empty in Phase 1. Therefore no
+production pack is selectable yet; `companion` and other packs belong to Phase
+2. Existing `config/presets/*.yaml` files remain installation examples, not
+runtime pack resources.
+
+This JSON is package data maintained by Moonbite, not a beginner-facing
+configuration surface. A future setup flow should let people choose a scenario
+and answer only the host-required questions; users are not expected to edit
+pack JSON.
+
+Each pack uses the `moon.scenario-pack.v1` envelope and an `overlay` mapping.
+Only module gates for heartbeat, autonomy, panel, and memory plus their
+corresponding behavior sections are allowed. State paths, timezone, delivery,
+model routes, `config_version`, and unknown roots are rejected before
+registration.
+
+When a pack is selected, the resolver deep-merges `pack < user`: mappings
+recurse, lists/scalars/`null` replace, and an explicit empty mapping replaces
+the pack mapping. The result then goes through the existing strict normalizer.
+Pack, user, and normalizer-default leaves receive deterministic JSON Pointer
+provenance (`pack:<name>`, `user`, or `default`); pointers escape `~` and `/`.
+
+Runtime keeps the complete effective configuration internally. Doctor output
+uses a redacted resolution view: timezone, state directory, delivery target,
+and model-route aliases are replaced with `<redacted>` when non-null. The
+model-facing status surface exposes only the selected public pack name.

--- a/moonbite_plugin/doctor.py
+++ b/moonbite_plugin/doctor.py
@@ -8,12 +8,12 @@ from typing import Any
 
 from .config import (
     ConfigError,
-    normalize_config,
     route_bindings,
     validate_known_aliases,
 )
 from .observer import HealthSnapshot, ScheduleProof
 from .platforms import UnsupportedPlatformError, detect_platform, state_root
+from .scenarios import ConfigResolution, ScenarioPackError, resolve_config
 
 
 def _looks_like_runtime(value: Any) -> bool:
@@ -94,6 +94,8 @@ def doctor_report(
     now: datetime | None = None,
     schedule_proof: ScheduleProof | None = None,
     include_private_paths: bool = False,
+    selected_pack: str | None = None,
+    resolution: ConfigResolution | None = None,
 ) -> dict[str, Any]:
     """Return configuration and optional runtime health without side effects.
 
@@ -121,17 +123,34 @@ def doctor_report(
         schedule_proof=schedule_proof,
     )
     try:
-        config = normalize_config(raw)
+        if runtime is not None and isinstance(
+            getattr(runtime, "resolution", None), ConfigResolution
+        ):
+            resolved = runtime.resolution
+        elif resolution is not None:
+            if not isinstance(resolution, ConfigResolution):
+                raise TypeError("resolution must be a ConfigResolution")
+            resolved = resolution
+        else:
+            resolved = resolve_config(raw, selected_pack)
+        config = resolved.effective_config
         validate_known_aliases(config, known_aliases)
         platform = detect_platform()
     except (ConfigError, UnsupportedPlatformError) as exc:
         unsupported = isinstance(exc, UnsupportedPlatformError)
+        error_code = (
+            exc.code
+            if isinstance(exc, ScenarioPackError)
+            else "unsupported_platform"
+            if unsupported
+            else "invalid_config"
+        )
         return {
             "ok": False,
             "plugin_loaded": runtime is not None,
             "config_valid": False,
             "error": type(exc).__name__,
-            "code": "unsupported_platform" if unsupported else "invalid_config",
+            "code": error_code,
             "message": (
                 "Moonbite supports macOS and Linux/WSL."
                 if unsupported
@@ -150,12 +169,16 @@ def doctor_report(
         }
 
     bindings = route_bindings(config)
+    redacted = resolved.redacted_config
+    redacted_routes = redacted.get("model_routes")
     health_available = health_result.get("available") is True
     return {
         "ok": True,
         "plugin_loaded": runtime is not None,
         "config_valid": True,
         "config_version": config["config_version"],
+        "scenario_pack": resolved.selected_pack,
+        "resolution": resolved.to_dict(redacted=True),
         "enabled_modules": sorted(
             name for name, enabled in config["modules"].items() if enabled
         ),
@@ -177,7 +200,10 @@ def doctor_report(
             None
             if bindings is None
             else {
-                "roles": bindings.__dict__,
+                "roles": {
+                    role: redacted_routes[role]["alias"]
+                    for role in ("main", "heartbeat", "hippocampus")
+                },
                 "resolution": (
                     "verified" if known_aliases is not None else "host_owned_not_probed"
                 ),

--- a/moonbite_plugin/plugin.py
+++ b/moonbite_plugin/plugin.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from .autonomy import ActivityProvider, AutonomyJudge
 from .components import RuntimeComponents
-from .config import normalize_config, route_bindings
+from .config import route_bindings
 from .conversation import ConversationBridge
 from .doctor import doctor_report
 from .hermes_adapter import (
@@ -27,6 +27,7 @@ from .memory import DiaryWriter
 from .memory_orchestration import MemoryOrchestrator, SourceRegistry
 from .service import MoonbiteRuntime, SessionContextResolver
 from .session import HOOK_ORDER
+from .scenarios import resolve_config
 
 TOOL_NAMES = (
     "moonbite_status",
@@ -42,6 +43,7 @@ TOOL_NAMES = (
 )
 
 _RAW_CONFIG_MISSING = object()
+_SELECTED_PACK_MISSING = object()
 _MOONBITE_RUNTIME_TYPE = MoonbiteRuntime
 
 
@@ -706,10 +708,22 @@ def _register_tools(
         )
 
 
-def _resolve_raw_config(ctx: Any, raw_config: Any) -> Any:
-    if raw_config is _RAW_CONFIG_MISSING:
-        return ctx.get_config("config", default={})
-    return raw_config
+def _resolve_scenario_pack(ctx: Any) -> str | None:
+    return ctx.get_config("scenario_pack", default=None)
+
+
+def _resolve_config_inputs(
+    ctx: Any,
+    raw_config: Any,
+    selected_pack: Any = _SELECTED_PACK_MISSING,
+) -> tuple[Any, str | None]:
+    explicit_raw = raw_config is not _RAW_CONFIG_MISSING
+    resolved_raw = raw_config if explicit_raw else ctx.get_config("config", default={})
+    if selected_pack is _SELECTED_PACK_MISSING:
+        resolved_pack = None if explicit_raw else _resolve_scenario_pack(ctx)
+    else:
+        resolved_pack = selected_pack
+    return resolved_raw, resolved_pack
 
 
 def _validated_plan(plan: RegistrationPlan | None) -> RegistrationPlan:
@@ -743,6 +757,7 @@ def build_runtime(
     ctx: Any,
     *,
     raw_config: Any = _RAW_CONFIG_MISSING,
+    selected_pack: str | None | object = _SELECTED_PACK_MISSING,
     components: RuntimeComponents | None = None,
     heartbeat_judge: Judge | None = None,
     autonomy_judge: AutonomyJudge | None = None,
@@ -755,8 +770,9 @@ def build_runtime(
     approval_adapter: Any = None,
 ) -> MoonbiteRuntime:
     """Construct the Moonbite runtime without registering host surfaces."""
-    raw_config = _resolve_raw_config(ctx, raw_config)
-    config = normalize_config(raw_config)
+    raw_config, selected_pack = _resolve_config_inputs(ctx, raw_config, selected_pack)
+    resolution = resolve_config(raw_config, selected_pack)
+    config = resolution.effective_config
     bindings = route_bindings(config)
 
     if heartbeat_judge is None and bindings is not None:
@@ -782,6 +798,8 @@ def build_runtime(
         memory_orchestrator=memory_orchestrator,
         source_registry=source_registry,
         approval_adapter=approval_adapter,
+        resolution=resolution,
+        resolution_raw_config=raw_config,
     )
 
     if bindings is not None:
@@ -800,6 +818,7 @@ def register_runtime(
     runtime: MoonbiteRuntime,
     *,
     raw_config: Any = _RAW_CONFIG_MISSING,
+    selected_pack: str | None | object = _SELECTED_PACK_MISSING,
     plan: RegistrationPlan | None = None,
 ) -> None:
     """Register one planned Hermes surface for a same-context prebuilt runtime.
@@ -808,17 +827,21 @@ def register_runtime(
     unique registration owner because Hermes exposes no portable registration
     transaction or rollback API.
     """
-    raw_config = _resolve_raw_config(ctx, raw_config)
-    config = normalize_config(raw_config)
-    bindings = route_bindings(config)
-    plan = _validated_plan(plan)
-
     if not isinstance(runtime, _MOONBITE_RUNTIME_TYPE):
         raise TypeError("runtime must be a MoonbiteRuntime")
     if getattr(runtime, "_registration_context_owner", None) is not ctx:
         raise ValueError("runtime was built for a different Hermes context")
-    if runtime.config != config:
+    raw_config, selected_pack = _resolve_config_inputs(ctx, raw_config, selected_pack)
+    if (
+        runtime._resolution_raw_config != raw_config
+        or runtime._resolution_selected_pack != selected_pack
+    ):
         raise ValueError("runtime config does not match registration config")
+    if runtime.config != runtime.resolution.effective_config:
+        raise ValueError("runtime config does not match registration resolution")
+    config = runtime.config
+    bindings = route_bindings(config)
+    plan = _validated_plan(plan)
 
     # This preflight intentionally protects only this call's zero-to-one
     # transition.  The host registry remains responsible for duplicate names.
@@ -911,11 +934,12 @@ def register(
     approval_adapter: Any = None,
     plan: RegistrationPlan | None = None,
 ) -> MoonbiteRuntime:
-    raw_config = _resolve_raw_config(ctx, _RAW_CONFIG_MISSING)
+    raw_config, selected_pack = _resolve_config_inputs(ctx, _RAW_CONFIG_MISSING)
     plan = _validated_plan(plan)
     runtime = build_runtime(
         ctx,
         raw_config=raw_config,
+        selected_pack=selected_pack,
         components=components,
         heartbeat_judge=heartbeat_judge,
         autonomy_judge=autonomy_judge,
@@ -927,5 +951,11 @@ def register(
         source_registry=source_registry,
         approval_adapter=approval_adapter,
     )
-    register_runtime(ctx, runtime, raw_config=raw_config, plan=plan)
+    register_runtime(
+        ctx,
+        runtime,
+        raw_config=raw_config,
+        selected_pack=selected_pack,
+        plan=plan,
+    )
     return runtime

--- a/moonbite_plugin/scenario_packs/__init__.py
+++ b/moonbite_plugin/scenario_packs/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in Moonbite scenario pack resources."""

--- a/moonbite_plugin/scenario_packs/index.json
+++ b/moonbite_plugin/scenario_packs/index.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": "moon.scenario-pack-index.v1",
+  "packs": {}
+}

--- a/moonbite_plugin/scenarios.py
+++ b/moonbite_plugin/scenarios.py
@@ -1,0 +1,383 @@
+"""Scenario-pack loading, merging, provenance, and safe inspection."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+from .config import ConfigError, normalize_config
+
+
+SCENARIO_PACK_RESOURCE_PACKAGE = "moonbite_plugin.scenario_packs"
+SCENARIO_PACK_INDEX_RESOURCE = "index.json"
+_INDEX_SCHEMA = "moon.scenario-pack-index.v1"
+_PACK_SCHEMA = "moon.scenario-pack.v1"
+_SELECTOR = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_RESOURCE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*\.json$")
+_PACK_ROOTS = frozenset({"modules", "heartbeat", "autonomy", "panel", "memory"})
+_PACK_MODULES = frozenset({"heartbeat", "autonomy", "panel", "memory"})
+_FORBIDDEN_ROOTS = frozenset(
+    {"config_version", "timezone", "state", "delivery", "model_routes"}
+)
+_MISSING = object()
+
+
+def _pointer(parts: tuple[Any, ...]) -> str:
+    if not parts:
+        return "/"
+    return "/" + "/".join(
+        str(part).replace("~", "~0").replace("/", "~1") for part in parts
+    )
+
+
+class ScenarioPackError(ConfigError):
+    """A safe, structured scenario-pack or merge failure."""
+
+    def __init__(self, code: str, path: str = "/", message: str | None = None):
+        self.code = code
+        self.path = path if path.startswith("/") else f"/{path}"
+        self.reason = message
+        detail = "" if message is None else f": {message}"
+        super().__init__(f"scenario pack {code} at {self.path}{detail}")
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigResolution:
+    """The one validated configuration result shared by runtime consumers."""
+
+    selected_pack: str | None
+    effective_config: dict[str, Any]
+    provenance: dict[str, str]
+
+    @property
+    def redacted_config(self) -> dict[str, Any]:
+        return redact_config(self.effective_config)
+
+    def to_dict(self, *, redacted: bool = True) -> dict[str, Any]:
+        return {
+            "selected_pack": self.selected_pack,
+            "effective_config": self.redacted_config
+            if redacted
+            else deepcopy(self.effective_config),
+            "provenance": dict(self.provenance),
+        }
+
+
+def _validate_selector(selected_pack: Any) -> str:
+    if type(selected_pack) is not str or _SELECTOR.fullmatch(selected_pack) is None:
+        raise ScenarioPackError("invalid_selector", "/scenario_pack")
+    return selected_pack
+
+
+def _resource_root(package: str | None = None) -> Any:
+    try:
+        return resources.files(
+            SCENARIO_PACK_RESOURCE_PACKAGE if package is None else package
+        )
+    except Exception as exc:  # noqa: BLE001 - package boundary
+        raise ScenarioPackError("missing_resource", "/") from exc
+
+
+def _read_json(root: Any, resource_name: str, *, code: str, path: str) -> Any:
+    try:
+        text = root.joinpath(resource_name).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ScenarioPackError("missing_resource", path) from exc
+    except Exception as exc:  # noqa: BLE001 - package resource boundary
+        raise ScenarioPackError("resource_read_failed", path) from exc
+    try:
+        return json.loads(text)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ScenarioPackError(code, path) from exc
+
+
+def _resource_name(value: Any, path: str) -> str:
+    if (
+        type(value) is not str
+        or "/" in value
+        or "\\" in value
+        or value in {"", ".", ".."}
+        or _RESOURCE_NAME.fullmatch(value) is None
+    ):
+        raise ScenarioPackError("invalid_resource_name", path)
+    return value
+
+
+def _catalog(package: str | None = None) -> tuple[Any, dict[str, str]]:
+    root = _resource_root(package)
+    value = _read_json(
+        root,
+        SCENARIO_PACK_INDEX_RESOURCE,
+        code="malformed_index",
+        path="/",
+    )
+    if not isinstance(value, Mapping):
+        raise ScenarioPackError("unsupported_index_schema", "/")
+    if set(value) != {"schema_version", "packs"}:
+        raise ScenarioPackError("unsupported_index_schema", "/")
+    if value.get("schema_version") != _INDEX_SCHEMA:
+        raise ScenarioPackError("unsupported_index_schema", "/schema_version")
+    packs = value.get("packs")
+    if not isinstance(packs, Mapping):
+        raise ScenarioPackError("malformed_index", "/packs")
+    catalog: dict[str, str] = {}
+    for name, resource_name in packs.items():
+        if type(name) is not str or _SELECTOR.fullmatch(name) is None:
+            raise ScenarioPackError("invalid_selector", _pointer(("packs", name)))
+        catalog[name] = _resource_name(resource_name, _pointer(("packs", name)))
+    return root, catalog
+
+
+def load_catalog(package: str | None = None) -> dict[str, str]:
+    """Load the fixed public selector-to-resource catalog."""
+
+    _root, catalog = _catalog(package)
+    return catalog
+
+
+def _validate_pack_overlay(overlay: Mapping[str, Any]) -> None:
+    for key in overlay:
+        path = _pointer((key,))
+        if key not in _PACK_ROOTS:
+            code = (
+                "forbidden_pack_field"
+                if key in _FORBIDDEN_ROOTS
+                else "unknown_pack_field"
+            )
+            raise ScenarioPackError(code, path)
+    modules = overlay.get("modules", _MISSING)
+    if isinstance(modules, Mapping):
+        for key in modules:
+            if key not in _PACK_MODULES:
+                code = (
+                    "forbidden_pack_field"
+                    if key == "runtime_core"
+                    else "unknown_pack_field"
+                )
+                raise ScenarioPackError(code, _pointer(("modules", key)))
+
+
+def load_pack(selected_pack: str, package: str | None = None) -> dict[str, Any]:
+    """Load and validate one catalog-selected pack overlay."""
+
+    selector = _validate_selector(selected_pack)
+    root, catalog = _catalog(package)
+    resource_name = catalog.get(selector)
+    if resource_name is None:
+        raise ScenarioPackError("unknown_pack", "/scenario_pack")
+    value = _read_json(
+        root,
+        resource_name,
+        code="malformed_json",
+        path=_pointer(("packs", selector)),
+    )
+    if not isinstance(value, Mapping):
+        raise ScenarioPackError("unsupported_pack_schema", "/")
+    if set(value) != {"schema_version", "name", "overlay"}:
+        raise ScenarioPackError("unsupported_pack_schema", "/")
+    if value.get("schema_version") != _PACK_SCHEMA:
+        raise ScenarioPackError("unsupported_pack_schema", "/schema_version")
+    if value.get("name") != selector:
+        raise ScenarioPackError("pack_name_mismatch", "/name")
+    overlay = value.get("overlay")
+    if not isinstance(overlay, Mapping):
+        raise ScenarioPackError("malformed_pack", "/overlay")
+    _validate_pack_overlay(overlay)
+    return deepcopy(dict(overlay))
+
+
+def _collect_explicit(
+    value: Any,
+    source: str,
+    path: tuple[Any, ...],
+    explicit: dict[tuple[Any, ...], str],
+) -> None:
+    if isinstance(value, Mapping):
+        if not value:
+            # The root object is structural, not a user-facing leaf.
+            if path:
+                explicit[path] = source
+            return
+        for key, child in value.items():
+            _collect_explicit(child, source, (*path, key), explicit)
+        return
+    explicit[path] = source
+
+
+def _merge_values(
+    pack_value: Any,
+    user_value: Any,
+    path: tuple[Any, ...],
+    explicit: dict[tuple[Any, ...], str],
+    pack_source: str,
+) -> Any:
+    pack_mapping = isinstance(pack_value, Mapping)
+    user_mapping = isinstance(user_value, Mapping)
+    if pack_mapping != user_mapping:
+        raise ScenarioPackError("merge_type_conflict", _pointer(path))
+    if pack_mapping:
+        if not user_value:
+            if path:
+                explicit[path] = "user"
+                return {}
+            # The top-level user object is structural; an omitted/empty user
+            # config must leave the selected pack overlay intact.
+            result = deepcopy(dict(pack_value))
+            _collect_explicit(result, pack_source, path, explicit)
+            return result
+        result: dict[Any, Any] = {}
+        keys = list(pack_value)
+        keys.extend(key for key in user_value if key not in pack_value)
+        for key in keys:
+            in_pack = key in pack_value
+            in_user = key in user_value
+            child_path = (*path, key)
+            if in_pack and in_user:
+                result[key] = _merge_values(
+                    pack_value[key],
+                    user_value[key],
+                    child_path,
+                    explicit,
+                    pack_source,
+                )
+            elif in_user:
+                result[key] = deepcopy(user_value[key])
+                _collect_explicit(user_value[key], "user", child_path, explicit)
+            else:
+                result[key] = deepcopy(pack_value[key])
+                _collect_explicit(pack_value[key], pack_source, child_path, explicit)
+        return result
+    # Both scalar/list/null values are literals; user wins on collision.
+    result = deepcopy(user_value)
+    _collect_explicit(result, "user", path, explicit)
+    return result
+
+
+def _provenance(
+    value: Any,
+    path: tuple[Any, ...],
+    explicit: Mapping[tuple[Any, ...], str],
+    result: dict[str, str],
+) -> None:
+    source = explicit.get(path)
+    if source is not None:
+        result[_pointer(path)] = source
+        # Explicit empty maps are intentional replacement leaves, even though
+        # normalize_config may fill them with inert defaults.
+        return
+    if isinstance(value, Mapping):
+        if not value:
+            result[_pointer(path)] = "default"
+            return
+        for key, child in value.items():
+            _provenance(child, (*path, key), explicit, result)
+        return
+    result[_pointer(path)] = "default"
+
+
+def _normalized_provenance(
+    raw: Any,
+    effective: dict[str, Any],
+    *,
+    explicit: Mapping[tuple[Any, ...], str] | None = None,
+) -> dict[str, str]:
+    if explicit is None:
+        explicit_map: dict[tuple[Any, ...], str] = {}
+        if raw is not None:
+            _collect_explicit(raw, "user", (), explicit_map)
+    else:
+        explicit_map = dict(explicit)
+    result: dict[str, str] = {}
+    _provenance(effective, (), explicit_map, result)
+    return result
+
+
+def resolve_config(
+    raw_config: Any, selected_pack: str | None = None
+) -> ConfigResolution:
+    """Resolve one optional pack and user config through the existing validator."""
+
+    if selected_pack is None:
+        effective = normalize_config(raw_config)
+        return ConfigResolution(
+            selected_pack=None,
+            effective_config=effective,
+            provenance=_normalized_provenance(raw_config, effective),
+        )
+
+    selector = _validate_selector(selected_pack)
+    if raw_config is not None and not isinstance(raw_config, Mapping):
+        # Keep the legacy no-pack error wording for the same invalid input.
+        raise ConfigError("config must be a mapping")
+    user = {} if raw_config is None else raw_config
+    overlay = load_pack(selector)
+    explicit: dict[tuple[Any, ...], str] = {}
+    merged = _merge_values(
+        overlay,
+        user,
+        (),
+        explicit,
+        f"pack:{selector}",
+    )
+    effective = normalize_config(merged)
+    return ConfigResolution(
+        selected_pack=selector,
+        effective_config=effective,
+        provenance=_normalized_provenance(
+            merged,
+            effective,
+            explicit=explicit,
+        ),
+    )
+
+
+def redact_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a safe inspection copy with deployment-owned values redacted."""
+
+    result = deepcopy(dict(config))
+
+    timezone = result.get("timezone")
+    if timezone is not None:
+        result["timezone"] = "<redacted>"
+
+    state = result.get("state")
+    if isinstance(state, Mapping):
+        state = dict(state)
+        if state.get("directory") is not None:
+            state["directory"] = "<redacted>"
+        result["state"] = state
+
+    delivery = result.get("delivery")
+    if isinstance(delivery, Mapping):
+        delivery = dict(delivery)
+        if delivery.get("target") is not None:
+            delivery["target"] = "<redacted>"
+        result["delivery"] = delivery
+
+    routes = result.get("model_routes")
+    if isinstance(routes, Mapping):
+        routes = dict(routes)
+        for role, route in list(routes.items()):
+            if not isinstance(route, Mapping):
+                continue
+            route = dict(route)
+            if route.get("alias") is not None:
+                route["alias"] = "<redacted>"
+            routes[role] = route
+        result["model_routes"] = routes
+    return result
+
+
+__all__ = [
+    "ConfigResolution",
+    "ScenarioPackError",
+    "load_catalog",
+    "load_pack",
+    "redact_config",
+    "resolve_config",
+]

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -20,7 +21,6 @@ from .autonomy import (
     ProviderRegistry,
 )
 from .components import RuntimeComponents, RuntimeComponentsError
-from .config import normalize_config
 from .conversation import ConversationBridge
 from .effects import EffectReceipt, EffectRecord
 from .example_providers import example_activity_providers
@@ -55,6 +55,7 @@ from .observer import HealthSnapshot, ObservationFact, Observer, ScheduleProof
 from .platforms import PlatformInfo, detect_platform, state_root
 from .runtime_core import StateError, ensure_bounded_text, new_id, parse_time, utc_now
 from .session import HOOK_ORDER, SessionContext, SessionHookReceipt
+from .scenarios import ConfigResolution, resolve_config
 
 logger = logging.getLogger(__name__)
 
@@ -146,8 +147,21 @@ class MoonbiteRuntime:
         memory_orchestrator: MemoryOrchestrator | None = None,
         source_registry: SourceRegistry | None = None,
         approval_adapter: Any = None,
+        resolution: ConfigResolution | None = None,
+        selected_pack: str | None = None,
+        resolution_raw_config: Any = _MISSING,
     ):
-        self.config = normalize_config(raw_config)
+        if resolution is None:
+            resolution = resolve_config(raw_config, selected_pack)
+        elif not isinstance(resolution, ConfigResolution):
+            raise TypeError("resolution must be a ConfigResolution")
+        self.resolution = resolution
+        self.config = resolution.effective_config
+        resolution_input = (
+            raw_config if resolution_raw_config is _MISSING else resolution_raw_config
+        )
+        self._resolution_raw_config = deepcopy(resolution_input)
+        self._resolution_selected_pack = resolution.selected_pack
         provided_components = components is not None
         if provided_components and root is not None:
             raise RuntimeComponentsError("multiple_state_writers")
@@ -659,6 +673,7 @@ class MoonbiteRuntime:
             ),
             "scheduler": "host_owned",
             "delivery_adapter": self.config["delivery"]["adapter"],
+            "scenario_pack": self.resolution.selected_pack,
             "model_routes": bindings,
             "registered_activity_providers": list(self.providers.names()),
             "active_controls": self._active_control_metadata(now=effective_now),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ moonbite = "moonbite_plugin"
 [tool.setuptools.packages.find]
 include = ["moonbite_plugin*"]
 
+[tool.setuptools.package-data]
+moonbite_plugin = ["scenario_packs/*.json"]
+
 [tool.ruff]
 target-version = "py311"
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -105,3 +105,30 @@ def test_doctor_runtime_uses_existing_runtime_health(tmp_path):
     assert report["plugin_loaded"] is True
     assert report["health"]["target_date"] == "2026-08-24"
     assert not (tmp_path / "controls.jsonl").exists()
+
+
+def test_doctor_exposes_redacted_runtime_resolution(tmp_path):
+    runtime = MoonbiteRuntime(
+        {
+            "timezone": "America/Los_Angeles",
+            "state": {"directory": "/private/state"},
+            "delivery": {"target": "private-target"},
+            "model_routes": {
+                "schema_version": "moon.model_route_bindings.v1",
+                "main": {"alias": "private_main"},
+                "heartbeat": {"alias": "private_heartbeat"},
+                "hippocampus": {"alias": "private_memory"},
+            },
+        },
+        root=tmp_path,
+    )
+
+    report = doctor_report(runtime)
+
+    assert report["scenario_pack"] is None
+    effective = report["resolution"]["effective_config"]
+    assert effective["timezone"] == "<redacted>"
+    assert effective["state"]["directory"] == "<redacted>"
+    assert effective["delivery"]["target"] == "<redacted>"
+    assert effective["model_routes"]["main"]["alias"] == "<redacted>"
+    assert report["model_routes"]["roles"]["main"] == "<redacted>"

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -352,6 +352,7 @@ def test_provided_standalone_bundle_is_not_an_injection_seam(tmp_path):
 class RecordingContext:
     def __init__(self, config: dict[str, Any] | None = None):
         self.config = {} if config is None else config
+        self.scenario_pack = None
         self.llm = object()
         self.tools: dict[str, dict[str, Any]] = {}
         self.hooks: dict[str, Any] = {}
@@ -360,8 +361,11 @@ class RecordingContext:
         self.hook_order: list[str] = []
 
     def get_config(self, key: str, default=None):
-        assert key == "config"
-        return self.config
+        if key == "config":
+            return self.config
+        if key == "scenario_pack":
+            return self.scenario_pack
+        return default
 
     def register_tool(self, **kwargs: Any):
         self.registered.append("tool")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -23,8 +23,9 @@ from moonbite_plugin.service import MoonbiteRuntime
 
 
 class FakeContext:
-    def __init__(self, config=None):
+    def __init__(self, config=None, scenario_pack=None):
         self.config = {} if config is None else config
+        self.scenario_pack = scenario_pack
         self.cli = None
         self.slash = None
         self.tools = {}
@@ -33,8 +34,11 @@ class FakeContext:
         self.llm = object()
 
     def get_config(self, key, default=None):
-        assert key == "config"
-        return self.config
+        if key == "config":
+            return self.config
+        if key == "scenario_pack":
+            return self.scenario_pack
+        return default
 
     def register_cli_command(self, **kwargs):
         self.cli = kwargs

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+import moonbite_plugin.scenarios as scenarios
+from moonbite_plugin.config import ConfigError, normalize_config
+from moonbite_plugin.plugin import build_runtime
+from moonbite_plugin.scenarios import (
+    ScenarioPackError,
+    load_catalog,
+    redact_config,
+    resolve_config,
+)
+
+
+def _resource_fixture(monkeypatch, tmp_path: Path, *, overlay: dict, name="fixture"):
+    (tmp_path / "index.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {name: f"{name}.json"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / f"{name}.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.scenario-pack.v1",
+                "name": name,
+                "overlay": overlay,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(scenarios.resources, "files", lambda _package: tmp_path)
+
+
+def test_no_pack_is_exact_normalizer_parity_and_does_not_read_resources(monkeypatch):
+    raw = {
+        "modules": {"panel": True},
+        "memory": {"search_limit": 12},
+    }
+    original = deepcopy(raw)
+
+    def fail_if_read(_package):
+        raise AssertionError("no-pack must not load scenario resources")
+
+    monkeypatch.setattr(scenarios.resources, "files", fail_if_read)
+    resolution = resolve_config(raw)
+
+    assert resolution.selected_pack is None
+    assert resolution.effective_config == normalize_config(raw)
+    assert raw == original
+    assert resolution.provenance["/modules/panel"] == "user"
+    assert resolution.provenance["/timezone"] == "default"
+
+
+def test_pack_user_merge_provenance_and_redaction(monkeypatch, tmp_path):
+    overlay = {
+        "modules": {"heartbeat": True},
+        "heartbeat": {
+            "default_snooze_minutes": 60,
+            "kinds": {"custom": {"enabled": True}},
+        },
+        "autonomy": {"providers": {"pack_provider": {"enabled": True}}},
+    }
+    _resource_fixture(monkeypatch, tmp_path, overlay=overlay)
+    raw = {
+        "modules": {"heartbeat": False},
+        "heartbeat": {"default_snooze_minutes": 90},
+        "state": {"directory": "/private/state"},
+        "delivery": {"target": "private-target"},
+        "model_routes": {
+            "schema_version": "moon.model_route_bindings.v1",
+            "main": {"alias": "private_main"},
+            "heartbeat": {"alias": "private_heartbeat"},
+            "hippocampus": {"alias": "private_hippocampus"},
+        },
+    }
+    original = deepcopy(raw)
+
+    resolution = resolve_config(raw, "fixture")
+
+    assert resolution.effective_config["modules"]["heartbeat"] is False
+    assert resolution.effective_config["heartbeat"]["default_snooze_minutes"] == 90
+    assert resolution.effective_config["autonomy"]["providers"]["pack_provider"] == {
+        "enabled": True,
+        "weight": 1,
+    }
+    assert resolution.provenance["/modules/heartbeat"] == "user"
+    assert resolution.provenance["/heartbeat/default_snooze_minutes"] == "user"
+    assert resolution.provenance["/heartbeat/kinds/custom/enabled"] == "pack:fixture"
+    assert resolution.provenance["/heartbeat/kinds/custom/profile"] == "default"
+    assert raw == original
+    safe = resolution.redacted_config
+    assert safe["timezone"] == "<redacted>"
+    assert safe["state"]["directory"] == "<redacted>"
+    assert safe["delivery"]["target"] == "<redacted>"
+    assert safe["model_routes"]["main"]["alias"] == "<redacted>"
+
+
+def test_empty_mapping_replaces_pack_map_and_lists_are_literals(monkeypatch, tmp_path):
+    _resource_fixture(
+        monkeypatch,
+        tmp_path,
+        overlay={
+            "autonomy": {
+                "providers": {
+                    "pack_provider": {"enabled": True},
+                }
+            },
+            "heartbeat": {"kinds": {"custom": {"bypass": []}}},
+        },
+    )
+    resolution = resolve_config(
+        {
+            "autonomy": {"providers": {}},
+            "heartbeat": {
+                "kinds": {
+                    "custom": {
+                        "profile": "urgent",
+                        "bypass": ["active_chat"],
+                    }
+                }
+            },
+            "delivery": {"target": None},
+        },
+        "fixture",
+    )
+
+    assert "pack_provider" not in resolution.effective_config["autonomy"]["providers"]
+    assert resolution.effective_config["heartbeat"]["kinds"]["custom"]["bypass"] == [
+        "active_chat"
+    ]
+    assert resolution.provenance["/autonomy/providers"] == "user"
+    assert resolution.provenance["/heartbeat/kinds/custom/bypass"] == "user"
+    assert resolution.effective_config["delivery"]["target"] is None
+
+
+@pytest.mark.parametrize(
+    ("selector", "code"),
+    [("../fixture", "invalid_selector"), ("unknown", "unknown_pack")],
+)
+def test_selector_validation_is_fail_closed(monkeypatch, tmp_path, selector, code):
+    _resource_fixture(monkeypatch, tmp_path, overlay={})
+    with pytest.raises(ScenarioPackError) as raised:
+        resolve_config({}, selector)
+    assert raised.value.code == code
+    assert "/" not in str(raised.value).split(" at ", 1)[-1].removeprefix("/")
+
+
+def test_forbidden_pack_root_and_merge_conflict_are_structured(monkeypatch, tmp_path):
+    _resource_fixture(monkeypatch, tmp_path, overlay={"timezone": "UTC"})
+    with pytest.raises(ScenarioPackError) as raised:
+        resolve_config({}, "fixture")
+    assert raised.value.code == "forbidden_pack_field"
+    assert raised.value.path == "/timezone"
+
+    _resource_fixture(monkeypatch, tmp_path, overlay={"panel": {"anchor_hour": 4}})
+    with pytest.raises(ScenarioPackError) as raised:
+        resolve_config({"panel": None}, "fixture")
+    assert raised.value.code == "merge_type_conflict"
+    assert raised.value.path == "/panel"
+
+
+@pytest.mark.parametrize(
+    ("index_payload", "pack_payload", "code", "path"),
+    [
+        (
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            None,
+            "missing_resource",
+            "/packs/fixture",
+        ),
+        (
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            "{not-json",
+            "malformed_json",
+            "/packs/fixture",
+        ),
+        (
+            {
+                "schema_version": "unsupported.index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            None,
+            "unsupported_index_schema",
+            "/schema_version",
+        ),
+        (
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            {
+                "schema_version": "unsupported.pack.v1",
+                "name": "fixture",
+                "overlay": {},
+            },
+            "unsupported_pack_schema",
+            "/schema_version",
+        ),
+        (
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            {
+                "schema_version": "moon.scenario-pack.v1",
+                "name": "other",
+                "overlay": {},
+            },
+            "pack_name_mismatch",
+            "/name",
+        ),
+        (
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            {
+                "schema_version": "moon.scenario-pack.v1",
+                "name": "fixture",
+                "overlay": {"unknown": {}},
+            },
+            "unknown_pack_field",
+            "/unknown",
+        ),
+        (
+            {
+                "schema_version": "moon.scenario-pack-index.v1",
+                "packs": {"fixture": "fixture.json"},
+            },
+            {
+                "schema_version": "moon.scenario-pack.v1",
+                "name": "fixture",
+                "overlay": {"modules": {"runtime_core": True}},
+            },
+            "forbidden_pack_field",
+            "/modules/runtime_core",
+        ),
+    ],
+    ids=(
+        "missing-resource",
+        "malformed-json",
+        "unsupported-index-schema",
+        "unsupported-pack-schema",
+        "pack-name-mismatch",
+        "unknown-root",
+        "forbidden-runtime-core",
+    ),
+)
+def test_pack_loader_failure_matrix(
+    monkeypatch,
+    tmp_path,
+    index_payload,
+    pack_payload,
+    code,
+    path,
+):
+    (tmp_path / "index.json").write_text(json.dumps(index_payload), encoding="utf-8")
+    if pack_payload is not None:
+        if isinstance(pack_payload, str):
+            pack_text = pack_payload
+        else:
+            pack_text = json.dumps(pack_payload)
+        (tmp_path / "fixture.json").write_text(pack_text, encoding="utf-8")
+    monkeypatch.setattr(scenarios.resources, "files", lambda _package: tmp_path)
+
+    with pytest.raises(ScenarioPackError) as raised:
+        resolve_config({}, "fixture")
+
+    error = raised.value
+    assert error.code == code
+    assert error.path == path
+    assert str(tmp_path) not in str(error)
+    assert str(tmp_path) not in error.args[0]
+
+
+def test_empty_production_catalog_is_a_valid_pack_resource():
+    assert load_catalog() == {}
+    with pytest.raises(ScenarioPackError, match="unknown_pack"):
+        resolve_config({}, "companion")
+
+
+def test_redaction_preserves_null_and_does_not_mutate_input():
+    config = {
+        "timezone": "UTC",
+        "state": {"directory": None},
+        "delivery": {"target": ""},
+        "model_routes": None,
+    }
+    original = deepcopy(config)
+    safe = redact_config(config)
+    assert safe["timezone"] == "<redacted>"
+    assert safe["state"]["directory"] is None
+    assert safe["delivery"]["target"] == "<redacted>"
+    assert config == original
+
+
+def test_no_pack_invalid_input_keeps_config_error_message():
+    with pytest.raises(ConfigError, match="config must be a mapping"):
+        resolve_config("not-a-mapping")
+
+
+def test_build_runtime_reads_sibling_selector_once(monkeypatch, tmp_path):
+    _resource_fixture(
+        monkeypatch,
+        tmp_path,
+        overlay={"modules": {"panel": True}},
+    )
+
+    calls = {"config": 0, "scenario_pack": 0}
+
+    class Context:
+        llm = object()
+
+        def get_config(self, key, default=None):
+            calls[key] += 1
+            values = {
+                "config": {
+                    "state": {"directory": str(tmp_path / "state")},
+                },
+                "scenario_pack": "fixture",
+            }
+            return values.get(key, default)
+
+    runtime = build_runtime(Context())
+    assert runtime.resolution.selected_pack == "fixture"
+    assert runtime.config["modules"]["panel"] is True
+    assert calls == {"config": 1, "scenario_pack": 1}


### PR DESCRIPTION
## Summary

- add an optional built-in scenario pack resolver backed by a fixed JSON catalog
- merge pack defaults beneath user configuration with deterministic provenance and safe redaction
- wire the sibling `scenario_pack` selector through plugin registration, runtime, status, and doctor
- package an intentionally empty Phase 1 catalog and document the beginner-facing boundary

No production scenario pack is selectable in Phase 1. Existing YAML presets remain installation examples rather than runtime pack sources.

## Validation

- 684 tests passed
- Ruff checks, formatting, compileall, and diff checks passed
- pinned Hermes contract passed with 10 tools and 5 hooks
- wheel and sdist build passed; both contain the empty catalog
- installed-wheel resource smoke test passed
- no runtime dependencies added

Part of #5