### PR TITLE
feat(heartbeat): track daily anchors per kind

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -45,6 +45,10 @@ cannot make a checkpoint eligible. The additive
 `0.1.0a1`; deployments must snapshot state before upgrading and must not point
 an older binary at upgraded state.
 
+Heartbeat cadence writes upgrade valid legacy state to schema v4. Deployments
+must snapshot cadence state before upgrading and must not point an older
+Moonbite binary at a state directory after a v4 cadence write.
+
 ---
 
 ## 2. Platform & Isolation Invariants

--- a/config/schema.json
+++ b/config/schema.json
@@ -223,8 +223,10 @@
               "judge": {"const": "required"},
               "host_only": {"const": true},
               "bypass": {
-                "maxItems": 1,
-                "items": {"const": "automatic_cooldown"}
+                "maxItems": 2,
+                "items": {
+                  "enum": ["automatic_cooldown", "manual_snooze"]
+                }
               }
             }
           }

--- a/moonbite_plugin/__init__.py
+++ b/moonbite_plugin/__init__.py
@@ -47,6 +47,7 @@ from .heartbeat import (
     CADENCE_SCHEMA_V1,
     CADENCE_SCHEMA_V2,
     CADENCE_SCHEMA_V3,
+    CADENCE_SCHEMA_V4,
     HeartbeatSilenceReceipt,
 )
 
@@ -112,5 +113,6 @@ __all__ = [
     "CADENCE_SCHEMA_V1",
     "CADENCE_SCHEMA_V2",
     "CADENCE_SCHEMA_V3",
+    "CADENCE_SCHEMA_V4",
     "HeartbeatSilenceReceipt",
 ]

--- a/moonbite_plugin/config.py
+++ b/moonbite_plugin/config.py
@@ -235,9 +235,12 @@ def _normalize_heartbeat_kinds(value: Any) -> dict[str, dict[str, Any]]:
             if judge != "required":
                 raise ConfigError(f"{path}.routine requires judge=required")
         elif profile == "daily_anchor":
-            if any(item != "automatic_cooldown" for item in bypass):
+            if any(
+                item not in {"automatic_cooldown", "manual_snooze"}
+                for item in bypass
+            ):
                 raise ConfigError(
-                    f"{path}.daily_anchor only allows automatic_cooldown bypass"
+                    f"{path}.daily_anchor only allows automatic_cooldown and manual_snooze bypass"
                 )
             if judge != "required":
                 raise ConfigError(f"{path}.daily_anchor requires judge=required")

--- a/moonbite_plugin/config.py
+++ b/moonbite_plugin/config.py
@@ -236,8 +236,7 @@ def _normalize_heartbeat_kinds(value: Any) -> dict[str, dict[str, Any]]:
                 raise ConfigError(f"{path}.routine requires judge=required")
         elif profile == "daily_anchor":
             if any(
-                item not in {"automatic_cooldown", "manual_snooze"}
-                for item in bypass
+                item not in {"automatic_cooldown", "manual_snooze"} for item in bypass
             ):
                 raise ConfigError(
                     f"{path}.daily_anchor only allows automatic_cooldown and manual_snooze bypass"

--- a/moonbite_plugin/heartbeat.py
+++ b/moonbite_plugin/heartbeat.py
@@ -39,10 +39,12 @@ from .session import SessionHookReceipt
 CADENCE_SCHEMA_V1 = "moon.heartbeat.cadence.v1"
 CADENCE_SCHEMA_V2 = "moon.heartbeat.cadence.v2"
 CADENCE_SCHEMA_V3 = "moon.heartbeat.cadence.v3"
-HEARTBEAT_CADENCE_SCHEMA = CADENCE_SCHEMA_V3
+CADENCE_SCHEMA_V4 = "moon.heartbeat.cadence.v4"
+HEARTBEAT_CADENCE_SCHEMA = CADENCE_SCHEMA_V4
 CADENCE_SCHEMA = HEARTBEAT_CADENCE_SCHEMA
 _PRIVATE_CONTACT_MAX = 128
 _VISIBLE_CONTACT_MAX = 128
+_DAILY_ANCHOR_MAX = 128
 _EFFECT_TERMINAL_MAX = 256
 _EFFECT_REF_MAX = 256
 _SILENCE_BACKOFF_RECEIPT_MAX = 256
@@ -231,6 +233,12 @@ def _strict_iso_date(value: Any, label: str) -> date:
     return decoded
 
 
+def _daily_anchor_kind(value: Any, label: str = "daily anchor kind") -> str:
+    if type(value) is not str or _HEARTBEAT_KIND_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{label} has invalid syntax")
+    return value
+
+
 def _json_time(value: datetime | None) -> str | None:
     return None if value is None else isoformat(value)
 
@@ -251,6 +259,8 @@ _CADENCE_OBSERVER_FIELDS = frozenset(
         "last_effect_at",
         "daily_anchor_epoch",
         "daily_anchor_completed",
+        "daily_anchor_epochs",
+        "daily_anchor_legacy_epoch",
         "private_contacts",
         "verified_visible_contacts",
         "private_contact_overflow_until",
@@ -288,6 +298,7 @@ def _read_cadence_state_lock_free(
         CADENCE_SCHEMA_V1,
         CADENCE_SCHEMA_V2,
         CADENCE_SCHEMA_V3,
+        CADENCE_SCHEMA_V4,
     }:
         return None, "unsupported_schema"
     if set(raw) - _CADENCE_OBSERVER_FIELDS:
@@ -674,7 +685,7 @@ def _compact_tail(values: Mapping[str, str], limit: int) -> dict[str, str]:
 
 def _empty_state() -> dict[str, Any]:
     return {
-        "schema_version": CADENCE_SCHEMA_V3,
+        "schema_version": CADENCE_SCHEMA_V4,
         "last_judge_at": None,
         "next_judge_at": None,
         "manual_cooldown_until": None,
@@ -682,6 +693,8 @@ def _empty_state() -> dict[str, Any]:
         "last_effect_at": None,
         "daily_anchor_epoch": None,
         "daily_anchor_completed": False,
+        "daily_anchor_epochs": {},
+        "daily_anchor_legacy_epoch": None,
         "private_contacts": {},
         "verified_visible_contacts": {},
         "private_contact_overflow_until": None,
@@ -694,6 +707,44 @@ def _empty_state() -> dict[str, Any]:
         "silence_backoff_streak": 0,
         "silence_backoff_last_completed_at": None,
     }
+
+
+def _normalise_daily_anchor_state(
+    raw: Mapping[str, Any],
+) -> tuple[dict[str, str], str | None, bool]:
+    """Decode exact-kind anchor evidence and the one-time legacy wildcard."""
+
+    legacy_fields = {"daily_anchor_epoch", "daily_anchor_completed"}
+    new_fields = {"daily_anchor_epochs", "daily_anchor_legacy_epoch"}
+    if set(raw) & new_fields:
+        if raw.get("schema_version") not in {None, CADENCE_SCHEMA_V4}:
+            raise ValueError("heartbeat daily anchor state has a mixed schema")
+        if set(raw) & legacy_fields:
+            raise ValueError("heartbeat daily anchor state mixes schemas")
+        mapping = raw.get("daily_anchor_epochs", {})
+        if not isinstance(mapping, Mapping):
+            raise ValueError("heartbeat daily_anchor_epochs must be an object")
+        if len(mapping) > _DAILY_ANCHOR_MAX:
+            raise ValueError("heartbeat daily_anchor_epochs exceeds its bound")
+        selected: dict[str, str] = {}
+        for kind, epoch in mapping.items():
+            _daily_anchor_kind(kind)
+            _strict_iso_date(epoch, f"daily_anchor_epochs.{kind}")
+            selected[kind] = epoch
+        legacy = raw.get("daily_anchor_legacy_epoch")
+        if legacy is not None:
+            _strict_iso_date(legacy, "heartbeat daily_anchor_legacy_epoch")
+        return selected, legacy, False
+
+    if raw.get("schema_version") == CADENCE_SCHEMA_V4 and set(raw) & legacy_fields:
+        raise ValueError("heartbeat daily anchor v4 requires per-kind state")
+    epoch = raw.get("daily_anchor_epoch")
+    if epoch is not None:
+        _strict_iso_date(epoch, "heartbeat daily_anchor_epoch")
+    completed = raw.get("daily_anchor_completed", False)
+    if type(completed) is not bool:
+        raise ValueError("heartbeat daily_anchor_completed is invalid")
+    return {}, epoch if completed else None, True
 
 
 def _normalise_silence_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
@@ -814,6 +865,7 @@ class HeartbeatCadence:
             CADENCE_SCHEMA_V1,
             CADENCE_SCHEMA_V2,
             CADENCE_SCHEMA_V3,
+            CADENCE_SCHEMA_V4,
         }:
             raise StateError("heartbeat cadence state has an unsupported schema")
         allowed = {
@@ -827,6 +879,8 @@ class HeartbeatCadence:
             "last_effect_at",
             "daily_anchor_epoch",
             "daily_anchor_completed",
+            "daily_anchor_epochs",
+            "daily_anchor_legacy_epoch",
             "private_contacts",
             "verified_visible_contacts",
             "private_contact_overflow_until",
@@ -870,17 +924,20 @@ class HeartbeatCadence:
             if len(set(decoded)) > 1:
                 raise StateError(f"heartbeat cadence {key} has conflicting timestamps")
             state[key] = decoded[0] if decoded else None
-        epoch = raw.get("daily_anchor_epoch")
-        if epoch is not None:
-            try:
-                _strict_iso_date(epoch, "heartbeat daily_anchor_epoch")
-            except ValueError as exc:
-                raise StateError("heartbeat daily_anchor_epoch is invalid") from exc
-        state["daily_anchor_epoch"] = epoch
-        completed = raw.get("daily_anchor_completed", False)
-        if type(completed) is not bool:
-            raise StateError("heartbeat daily_anchor_completed is invalid")
-        state["daily_anchor_completed"] = completed
+        try:
+            anchor_epochs, legacy_epoch, _legacy_state = _normalise_daily_anchor_state(
+                raw
+            )
+        except ValueError as exc:
+            raise StateError("heartbeat daily anchor state is invalid") from exc
+        state["daily_anchor_epochs"] = anchor_epochs
+        state["daily_anchor_legacy_epoch"] = legacy_epoch
+        # Keep the old fields in the in-memory snapshot for direct callers. The
+        # mapping and legacy epoch are the canonical v4 state.
+        state["daily_anchor_epoch"] = anchor_epochs.get("daily_anchor") or legacy_epoch
+        state["daily_anchor_completed"] = bool(
+            anchor_epochs.get("daily_anchor") or legacy_epoch
+        )
         for key in (
             "private_contacts",
             "verified_visible_contacts",
@@ -980,7 +1037,7 @@ class HeartbeatCadence:
     @staticmethod
     def _serialise(state: Mapping[str, Any]) -> dict[str, Any]:
         return {
-            "schema_version": CADENCE_SCHEMA_V3,
+            "schema_version": CADENCE_SCHEMA_V4,
             "last_judge_at": state.get("last_judge_at"),
             "next_judge_at": state.get("next_judge_at"),
             "manual_cooldown_until": state.get("manual_cooldown_until"),
@@ -988,8 +1045,8 @@ class HeartbeatCadence:
             "manual_until": state.get("manual_cooldown_until"),
             "auto_until": state.get("automatic_cooldown_until"),
             "last_effect_at": state.get("last_effect_at"),
-            "daily_anchor_epoch": state.get("daily_anchor_epoch"),
-            "daily_anchor_completed": bool(state.get("daily_anchor_completed", False)),
+            "daily_anchor_epochs": dict(state.get("daily_anchor_epochs", {})),
+            "daily_anchor_legacy_epoch": state.get("daily_anchor_legacy_epoch"),
             "private_contacts": dict(state.get("private_contacts", {})),
             "verified_visible_contacts": dict(
                 state.get("verified_visible_contacts", {})
@@ -1354,25 +1411,40 @@ class HeartbeatCadence:
     def daily_anchor_epoch(self, now: datetime | None = None) -> str:
         return self._anchor_epoch(self._now(now))
 
-    def daily_anchor_due(self, now: datetime | None = None) -> bool:
+    def daily_anchor_due(
+        self, now: datetime | None = None, *, kind: str = "daily_anchor"
+    ) -> bool:
+        selected_kind = _daily_anchor_kind(kind)
         epoch = self.daily_anchor_epoch(now)
         if not self.path.exists():
             return True
         with file_lock(self.lock_path):
             state = self._load()
-        return not (
-            state["daily_anchor_completed"] and state["daily_anchor_epoch"] == epoch
-        )
+        if state["daily_anchor_legacy_epoch"] == epoch:
+            return False
+        return state["daily_anchor_epochs"].get(selected_kind) != epoch
 
     def mark_daily_anchor(
-        self, epoch: str | None = None, *, now: datetime | None = None
+        self,
+        epoch: str | None = None,
+        *,
+        kind: str = "daily_anchor",
+        now: datetime | None = None,
     ) -> str:
+        selected_kind = _daily_anchor_kind(kind)
         selected = epoch if epoch is not None else self.daily_anchor_epoch(now)
         _strict_iso_date(selected, "daily anchor epoch")
         with file_lock(self.lock_path):
             state = self._load()
-            state["daily_anchor_epoch"] = selected
-            state["daily_anchor_completed"] = True
+            epochs = dict(state["daily_anchor_epochs"])
+            if selected_kind not in epochs and len(epochs) >= _DAILY_ANCHOR_MAX:
+                raise StateError("heartbeat daily_anchor_epochs exceeds its bound")
+            epochs[selected_kind] = selected
+            state["daily_anchor_epochs"] = epochs
+            state["daily_anchor_epoch"] = (
+                epochs.get("daily_anchor") or state["daily_anchor_legacy_epoch"]
+            )
+            state["daily_anchor_completed"] = bool(state["daily_anchor_epoch"])
             self._save(state)
         return selected
 
@@ -1395,8 +1467,18 @@ class HeartbeatCadence:
         next_judge_at: datetime | str | None = None,
         cadence_minutes: int | None = None,
         anchor_epoch: str | None = None,
+        anchor_kind: str | None = None,
     ) -> datetime:
         effective_now = self._now(now)
+        if anchor_kind is not None and anchor_epoch is None:
+            raise ValueError("anchor_kind requires anchor_epoch")
+        if anchor_epoch is not None:
+            _strict_iso_date(anchor_epoch, "anchor_epoch")
+        selected_anchor_kind = (
+            _daily_anchor_kind(anchor_kind)
+            if anchor_kind is not None
+            else "daily_anchor"
+        )
         if next_judge_at is not None:
             selected = _optional_time(next_judge_at, "next_judge_at")
             assert selected is not None
@@ -1407,7 +1489,6 @@ class HeartbeatCadence:
                 raise ValueError("cadence_minutes is out of bounds")
             selected = effective_now + timedelta(minutes=cadence_minutes)
         elif anchor_epoch is not None:
-            _strict_iso_date(anchor_epoch, "anchor_epoch")
             local = effective_now.astimezone(self.timezone)
             next_date = local.date() + timedelta(days=1)
             selected = datetime(
@@ -1424,8 +1505,18 @@ class HeartbeatCadence:
             state["last_judge_at"] = isoformat(effective_now)
             state["next_judge_at"] = isoformat(selected)
             if anchor_epoch is not None:
-                state["daily_anchor_epoch"] = anchor_epoch
-                state["daily_anchor_completed"] = True
+                epochs = dict(state["daily_anchor_epochs"])
+                if (
+                    selected_anchor_kind not in epochs
+                    and len(epochs) >= _DAILY_ANCHOR_MAX
+                ):
+                    raise StateError("heartbeat daily_anchor_epochs exceeds its bound")
+                epochs[selected_anchor_kind] = anchor_epoch
+                state["daily_anchor_epochs"] = epochs
+                state["daily_anchor_epoch"] = (
+                    epochs.get("daily_anchor") or state["daily_anchor_legacy_epoch"]
+                )
+                state["daily_anchor_completed"] = bool(state["daily_anchor_epoch"])
             self._save(state)
         return selected
 
@@ -1643,15 +1734,25 @@ class HeartbeatCadence:
             last = _optional_time(state["last_judge_at"], "last_judge_at")
             next_at = effective_now if last is None else last + self.judge_interval
         recent_kind, recent_at = self._recent_from_state(state, effective_now)
+        anchor_epochs = dict(state["daily_anchor_epochs"])
+        default_anchor_epoch = (
+            anchor_epochs.get("daily_anchor") or state["daily_anchor_legacy_epoch"]
+        )
         return {
-            "schema_version": CADENCE_SCHEMA_V3,
+            "schema_version": CADENCE_SCHEMA_V4,
             "last_judge_at": state["last_judge_at"],
             "next_judge_at": isoformat(next_at),
             "manual_cooldown_until": state["manual_cooldown_until"],
             "automatic_cooldown_until": state["automatic_cooldown_until"],
             "last_effect_at": state["last_effect_at"],
-            "daily_anchor_epoch": state["daily_anchor_epoch"],
-            "daily_anchor_completed": state["daily_anchor_completed"],
+            # The old fields remain as a compatibility view for the default
+            # kind; per-kind callers must use daily_anchor_epochs.
+            "daily_anchor_epoch": default_anchor_epoch,
+            "daily_anchor_completed": bool(
+                default_anchor_epoch == self._anchor_epoch(effective_now)
+            ),
+            "daily_anchor_epochs": anchor_epochs,
+            "daily_anchor_legacy_epoch": state["daily_anchor_legacy_epoch"],
             "daily_anchor_hour": self.anchor_hour,
             "timezone": self.timezone_name,
             "last_private_contact_at": state["last_private_contact_at"],
@@ -1740,13 +1841,12 @@ class HeartbeatCadence:
             ):
                 raise ValueError("silence backoff streak is invalid")
 
+            anchor_epochs, legacy_epoch, legacy_state = _normalise_daily_anchor_state(
+                raw
+            )
             completed_present = "daily_anchor_completed" in raw
             completed = raw.get("daily_anchor_completed", False)
-            if type(completed) is not bool:
-                raise ValueError("daily anchor completion is invalid")
             epoch = raw.get("daily_anchor_epoch")
-            if epoch is not None:
-                _strict_iso_date(epoch, "daily anchor epoch")
 
             contact_maps: dict[str, dict[str, datetime]] = {}
             for name in ("private_contacts", "verified_visible_contacts"):
@@ -1806,6 +1906,8 @@ class HeartbeatCadence:
                 "last_effect_at",
                 "daily_anchor_epoch",
                 "daily_anchor_completed",
+                "daily_anchor_epochs",
+                "daily_anchor_legacy_epoch",
                 "private_contacts",
                 "verified_visible_contacts",
                 "effect_terminals",
@@ -1888,7 +1990,7 @@ class HeartbeatCadence:
                         counts={"judge_schedule_entries": 1},
                     )
                 )
-            if epoch is not None:
+            if legacy_state and epoch is not None:
                 target_epoch = target_date.isoformat()
                 current_epoch = self._anchor_epoch(now)
                 if not completed_present:
@@ -1923,6 +2025,8 @@ class HeartbeatCadence:
                     anchor_state = "neutral" if completed else "current"
                     anchor_refs = (f"anchor:{epoch}",)
                     anchor_counts = {"anchor_entries": 1}
+                anchor_refs = (*anchor_refs, "migration:legacy")
+                anchor_counts = {**anchor_counts, "legacy": 1}
                 facts.append(
                     _observer_fact(
                         key="heartbeat:anchor",
@@ -1933,6 +2037,62 @@ class HeartbeatCadence:
                         counts=anchor_counts,
                     )
                 )
+            elif anchor_epochs or legacy_epoch is not None:
+                target_epoch = target_date.isoformat()
+                current_epoch = self._anchor_epoch(now)
+
+                def append_anchor_fact(
+                    kind: str, anchor_epoch: str, *, legacy: bool = False
+                ) -> None:
+                    if anchor_epoch != target_epoch:
+                        anchor_code = "heartbeat_anchor_outside_target"
+                        anchor_state = "neutral"
+                        anchor_refs = (
+                            f"anchor:{anchor_epoch}",
+                            f"target:{target_epoch}",
+                            f"current:{current_epoch}",
+                        )
+                        anchor_counts = {"anchor_entries": 1, "outside_target": 1}
+                    elif anchor_epoch != current_epoch:
+                        anchor_code = "heartbeat_anchor_stale_observed"
+                        anchor_state = "neutral"
+                        anchor_refs = (
+                            f"anchor:{anchor_epoch}",
+                            f"target:{target_epoch}",
+                            f"current:{current_epoch}",
+                        )
+                        anchor_counts = {"anchor_entries": 1, "stale": 1}
+                    else:
+                        anchor_code = (
+                            "heartbeat_anchor_legacy_completed"
+                            if legacy
+                            else "heartbeat_anchor_completed"
+                        )
+                        anchor_state = "neutral"
+                        anchor_refs = (
+                            f"anchor:{anchor_epoch}",
+                            f"kind:{kind}",
+                            "completion:legacy" if legacy else "completion:exact",
+                        )
+                        anchor_counts = {
+                            "anchor_entries": 1,
+                            "legacy": int(legacy),
+                        }
+                    facts.append(
+                        _observer_fact(
+                            key=f"heartbeat:anchor:{kind}",
+                            code=anchor_code,
+                            state=anchor_state,
+                            target_date=target_date,
+                            refs=anchor_refs,
+                            counts=anchor_counts,
+                        )
+                    )
+
+                if legacy_epoch is not None:
+                    append_anchor_fact("legacy", legacy_epoch, legacy=True)
+                for kind, anchor_epoch in sorted(anchor_epochs.items()):
+                    append_anchor_fact(kind, anchor_epoch)
 
             for name, code, key in (
                 (
@@ -2581,7 +2741,7 @@ class HeartbeatEngine:
             )
         if is_anchor:
             try:
-                due = self.cadence.daily_anchor_due(now)
+                due = self.cadence.daily_anchor_due(now, kind=candidate.kind)
             except AttributeError:
                 # Compatibility fallback for a minimal injected cadence port.
                 # A durable cadence implementation remains the authority when
@@ -3840,11 +4000,16 @@ class HeartbeatEngine:
             except AttributeError:
                 pass
         try:
+            mark_kwargs = {
+                "now": now,
+                "next_judge_at": decision.next_judge_at,
+                "cadence_minutes": decision.cadence_minutes,
+                "anchor_epoch": anchor_epoch,
+            }
+            if anchor_epoch is not None:
+                mark_kwargs["anchor_kind"] = candidate.kind
             next_judge = self.cadence.mark_judge(
-                now=now,
-                next_judge_at=decision.next_judge_at,
-                cadence_minutes=decision.cadence_minutes,
-                anchor_epoch=anchor_epoch,
+                **mark_kwargs,
             )
         except AttributeError:
             next_judge = (
@@ -3940,6 +4105,8 @@ class HeartbeatEngine:
 __all__ = [
     "CADENCE_SCHEMA_V1",
     "CADENCE_SCHEMA_V2",
+    "CADENCE_SCHEMA_V3",
+    "CADENCE_SCHEMA_V4",
     "CADENCE_SCHEMA",
     "HEARTBEAT_CADENCE_SCHEMA",
     "HEARTBEAT_BYPASSES",

--- a/moonbite_plugin/heartbeat.py
+++ b/moonbite_plugin/heartbeat.py
@@ -796,6 +796,8 @@ def _normalise_daily_anchor_state(
     completed = raw.get("daily_anchor_completed", False)
     if type(completed) is not bool:
         raise ValueError("heartbeat daily_anchor_completed is invalid")
+    if completed and epoch is None:
+        raise ValueError("heartbeat completed daily anchor requires an epoch")
     return {}, epoch if completed else None, True
 
 
@@ -2796,10 +2798,17 @@ class HeartbeatEngine:
                 # A durable cadence implementation remains the authority when
                 # it exposes daily_anchor_due().
                 due = completed is not True
-            elif _accepts_keyword(daily_anchor_due, "kind"):
-                due = daily_anchor_due(now, kind=candidate.kind)
             else:
-                due = daily_anchor_due(now)
+                try:
+                    due = (
+                        daily_anchor_due(now, kind=candidate.kind)
+                        if _accepts_keyword(daily_anchor_due, "kind")
+                        else daily_anchor_due(now)
+                    )
+                except Exception as exc:
+                    raise StateError(
+                        "heartbeat cadence daily_anchor_due failed"
+                    ) from exc
             return due, None if due else self._next_due(candidate, now)
         explicit = context.get("due")
         if explicit is not None and type(explicit) is not bool:
@@ -4048,10 +4057,19 @@ class HeartbeatEngine:
             )
         anchor_epoch = None
         if policy.profile == "daily_anchor":
-            try:
-                anchor_epoch = self.cadence.daily_anchor_epoch(now)
-            except AttributeError:
-                pass
+            daily_anchor_epoch = getattr(self.cadence, "daily_anchor_epoch", None)
+            if callable(daily_anchor_epoch):
+                try:
+                    anchor_epoch = daily_anchor_epoch(now)
+                except Exception:
+                    return self._result(
+                        "failed",
+                        "cadence_state_error",
+                        candidate_id,
+                        gate,
+                        code=HeartbeatReasonCode.CADENCE_ERROR,
+                        decision=decision,
+                    )
         mark_judge = getattr(self.cadence, "mark_judge", None)
         if callable(mark_judge):
             mark_kwargs = {

--- a/moonbite_plugin/heartbeat.py
+++ b/moonbite_plugin/heartbeat.py
@@ -239,6 +239,24 @@ def _daily_anchor_kind(value: Any, label: str = "daily anchor kind") -> str:
     return value
 
 
+def _accepts_keyword(method: Callable[..., Any], keyword: str) -> bool:
+    """Return whether a callable explicitly supports one keyword."""
+
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        return False
+    parameter = parameters.get(keyword)
+    return (
+        parameter is not None
+        and parameter.kind
+        in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
+    ) or any(item.kind is inspect.Parameter.VAR_KEYWORD for item in parameters.values())
+
+
 def _json_time(value: datetime | None) -> str | None:
     return None if value is None else isoformat(value)
 
@@ -773,6 +791,8 @@ def _normalise_daily_anchor_state(
     epoch = raw.get("daily_anchor_epoch")
     if epoch is not None:
         _strict_iso_date(epoch, "heartbeat daily_anchor_epoch")
+        if "daily_anchor_completed" not in raw:
+            raise ValueError("heartbeat daily_anchor_completed is required with epoch")
     completed = raw.get("daily_anchor_completed", False)
     if type(completed) is not bool:
         raise ValueError("heartbeat daily_anchor_completed is invalid")
@@ -1780,9 +1800,7 @@ class HeartbeatCadence:
             # The old fields remain as a compatibility view for the default
             # kind; per-kind callers must use daily_anchor_epochs.
             "daily_anchor_epoch": default_anchor_epoch,
-            "daily_anchor_completed": bool(
-                default_anchor_epoch == self._anchor_epoch(effective_now)
-            ),
+            "daily_anchor_completed": bool(default_anchor_epoch),
             "daily_anchor_epochs": anchor_epochs,
             "daily_anchor_legacy_epoch": state["daily_anchor_legacy_epoch"],
             "daily_anchor_hour": self.anchor_hour,
@@ -2772,13 +2790,16 @@ class HeartbeatEngine:
                 "anchor_completed_for_epoch requires a daily_anchor kind profile"
             )
         if is_anchor:
-            try:
-                due = self.cadence.daily_anchor_due(now, kind=candidate.kind)
-            except AttributeError:
+            daily_anchor_due = getattr(self.cadence, "daily_anchor_due", None)
+            if not callable(daily_anchor_due):
                 # Compatibility fallback for a minimal injected cadence port.
                 # A durable cadence implementation remains the authority when
                 # it exposes daily_anchor_due().
                 due = completed is not True
+            elif _accepts_keyword(daily_anchor_due, "kind"):
+                due = daily_anchor_due(now, kind=candidate.kind)
+            else:
+                due = daily_anchor_due(now)
             return due, None if due else self._next_due(candidate, now)
         explicit = context.get("due")
         if explicit is not None and type(explicit) is not bool:
@@ -4031,33 +4052,34 @@ class HeartbeatEngine:
                 anchor_epoch = self.cadence.daily_anchor_epoch(now)
             except AttributeError:
                 pass
-        try:
+        mark_judge = getattr(self.cadence, "mark_judge", None)
+        if callable(mark_judge):
             mark_kwargs = {
                 "now": now,
                 "next_judge_at": decision.next_judge_at,
                 "cadence_minutes": decision.cadence_minutes,
                 "anchor_epoch": anchor_epoch,
             }
-            if anchor_epoch is not None:
+            if anchor_epoch is not None and _accepts_keyword(mark_judge, "anchor_kind"):
                 mark_kwargs["anchor_kind"] = candidate.kind
-            next_judge = self.cadence.mark_judge(
-                **mark_kwargs,
-            )
-        except AttributeError:
+        if not callable(mark_judge):
             next_judge = (
                 _optional_time(decision.next_judge_at, "next_judge_at")
                 if decision.next_judge_at is not None
                 else None
             )
-        except Exception:
-            return self._result(
-                "failed",
-                "cadence_state_error",
-                candidate_id,
-                gate,
-                code=HeartbeatReasonCode.CADENCE_ERROR,
-                decision=decision,
-            )
+        else:
+            try:
+                next_judge = mark_judge(**mark_kwargs)
+            except Exception:
+                return self._result(
+                    "failed",
+                    "cadence_state_error",
+                    candidate_id,
+                    gate,
+                    code=HeartbeatReasonCode.CADENCE_ERROR,
+                    decision=decision,
+                )
         if not decision.wake_main and not decision.dm_user:
             if decision.allow_autonomy is True or decision.maintenance is True:
                 return self._result(

--- a/moonbite_plugin/heartbeat.py
+++ b/moonbite_plugin/heartbeat.py
@@ -128,7 +128,7 @@ class HeartbeatKindPolicy:
         if self.profile == "daily_anchor" and (
             not self.host_only
             or self.judge != "required"
-            or not self.bypass <= {"automatic_cooldown"}
+            or not self.bypass <= {"automatic_cooldown", "manual_snooze"}
         ):
             raise ValueError("daily_anchor heartbeat policy is fixed")
         if self.profile == "urgent" and (
@@ -716,21 +716,53 @@ def _normalise_daily_anchor_state(
 
     legacy_fields = {"daily_anchor_epoch", "daily_anchor_completed"}
     new_fields = {"daily_anchor_epochs", "daily_anchor_legacy_epoch"}
-    if set(raw) & new_fields:
-        if raw.get("schema_version") not in {None, CADENCE_SCHEMA_V4}:
-            raise ValueError("heartbeat daily anchor state has a mixed schema")
-        if set(raw) & legacy_fields:
-            raise ValueError("heartbeat daily anchor state mixes schemas")
-        mapping = raw.get("daily_anchor_epochs", {})
-        if not isinstance(mapping, Mapping):
+    fields = set(raw)
+    schema = raw.get("schema_version")
+
+    def normalise_epochs(value: Any) -> dict[str, str]:
+        if not isinstance(value, Mapping):
             raise ValueError("heartbeat daily_anchor_epochs must be an object")
-        if len(mapping) > _DAILY_ANCHOR_MAX:
+        if len(value) > _DAILY_ANCHOR_MAX:
             raise ValueError("heartbeat daily_anchor_epochs exceeds its bound")
         selected: dict[str, str] = {}
-        for kind, epoch in mapping.items():
+        for kind, epoch in value.items():
             _daily_anchor_kind(kind)
             _strict_iso_date(epoch, f"daily_anchor_epochs.{kind}")
             selected[kind] = epoch
+        return selected
+
+    # Early per-kind hosts wrote an exact map under the v3 schema while keeping
+    # the two old fields as a compatibility summary. Accept only the bounded,
+    # internally consistent shape and let the next normal write persist v4.
+    if schema == CADENCE_SCHEMA_V3 and "daily_anchor_epochs" in fields:
+        if "daily_anchor_legacy_epoch" in fields:
+            raise ValueError("heartbeat daily anchor state has a mixed schema")
+        present_legacy = fields & legacy_fields
+        if present_legacy not in (set(), legacy_fields):
+            raise ValueError("heartbeat daily anchor transition is incomplete")
+        selected = normalise_epochs(raw["daily_anchor_epochs"])
+        if not present_legacy:
+            return selected, None, False
+        epoch = raw.get("daily_anchor_epoch")
+        if epoch is not None:
+            _strict_iso_date(epoch, "heartbeat daily_anchor_epoch")
+        completed = raw.get("daily_anchor_completed")
+        if type(completed) is not bool:
+            raise ValueError("heartbeat daily_anchor_completed is invalid")
+        if completed != (epoch is not None):
+            raise ValueError("heartbeat daily anchor summary is inconsistent")
+        if selected:
+            if not completed or epoch not in selected.values():
+                raise ValueError("heartbeat daily anchor summary conflicts with map")
+            return selected, None, False
+        return selected, epoch, False
+
+    if set(raw) & new_fields:
+        if schema not in {None, CADENCE_SCHEMA_V4}:
+            raise ValueError("heartbeat daily anchor state has a mixed schema")
+        if set(raw) & legacy_fields:
+            raise ValueError("heartbeat daily anchor state mixes schemas")
+        selected = normalise_epochs(raw.get("daily_anchor_epochs", {}))
         legacy = raw.get("daily_anchor_legacy_epoch")
         if legacy is not None:
             _strict_iso_date(legacy, "heartbeat daily_anchor_legacy_epoch")

--- a/tests/fixtures/config_cases.json
+++ b/tests/fixtures/config_cases.json
@@ -64,6 +64,21 @@
       }
     },
     {
+      "id": "heartbeat_daily_anchor_manual_bypasses",
+      "config": {
+        "heartbeat": {
+          "kinds": {
+            "anchor_probe": {
+              "profile": "daily_anchor",
+              "judge": "required",
+              "host_only": true,
+              "bypass": ["automatic_cooldown", "manual_snooze"]
+            }
+          }
+        }
+      }
+    },
+    {
       "id": "heartbeat_urgent_both_bypasses",
       "config": {
         "heartbeat": {
@@ -302,20 +317,6 @@
         "heartbeat": {
           "kinds": {
             "routine_probe": {"profile": "routine", "judge": "skip"}
-          }
-        }
-      }
-    },
-    {
-      "id": "heartbeat_daily_anchor_manual_bypass_forbidden",
-      "config": {
-        "heartbeat": {
-          "kinds": {
-            "anchor_probe": {
-              "profile": "daily_anchor",
-              "host_only": true,
-              "bypass": ["manual_snooze"]
-            }
           }
         }
       }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,6 +99,13 @@ def test_custom_heartbeat_kind_is_normalized_with_safe_defaults():
         ("routine", [], "required", True),
         ("daily_anchor", [], "required", True),
         ("daily_anchor", ["automatic_cooldown"], "required", True),
+        ("daily_anchor", ["manual_snooze"], "required", True),
+        (
+            "daily_anchor",
+            ["automatic_cooldown", "manual_snooze"],
+            "required",
+            True,
+        ),
         ("urgent", [], "required", True),
         ("urgent", ["automatic_cooldown"], "required", True),
         ("urgent", ["manual_snooze"], "required", True),
@@ -154,10 +161,7 @@ def test_heartbeat_kind_profile_boundaries_are_accepted(
     [
         ({"profile": "routine", "bypass": ["manual_snooze"]}, "routine"),
         ({"profile": "routine", "judge": "skip"}, "routine"),
-        (
-            {"profile": "daily_anchor", "bypass": ["manual_snooze"]},
-            "daily_anchor",
-        ),
+        ({"profile": "daily_anchor", "bypass": ["active_chat"]}, "daily_anchor"),
         ({"profile": "daily_anchor", "host_only": False}, "daily_anchor"),
         ({"profile": "urgent", "judge": "skip"}, "urgent"),
         ({"profile": "urgent", "host_only": False}, "urgent"),

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -531,7 +532,7 @@ def test_daily_anchor_profile_owns_due_state_without_context_flags(tmp_path):
         HeartbeatReasonCode.NO_EVENT,
     )
     assert judge.calls == 1
-    assert cadence.snapshot()["daily_anchor_completed"] is True
+    assert cadence.snapshot()["daily_anchor_epochs"] == {"day_open": "2026-08-22"}
 
 
 @pytest.mark.parametrize(
@@ -875,6 +876,235 @@ def test_daily_anchor_is_durable_and_schedules_next_anchor(tmp_path):
     assert snapshot["daily_anchor_epoch"] == epoch
     assert snapshot["daily_anchor_completed"] is True
     assert snapshot["next_judge_at"].startswith("2026-08-23T06:00:00")
+
+
+def test_daily_anchor_state_is_independent_per_kind(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW, anchor_hour=6)
+    epoch = cadence.daily_anchor_epoch(NOW)
+
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is True
+    assert cadence.daily_anchor_due(NOW, kind="day_close") is True
+
+    cadence.mark_daily_anchor(epoch, kind="day_open")
+
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is False
+    assert cadence.daily_anchor_due(NOW, kind="day_close") is True
+
+    cadence.mark_judge(now=NOW, anchor_epoch=epoch, anchor_kind="day_close")
+    snapshot = cadence.snapshot(now=NOW)
+
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is False
+    assert cadence.daily_anchor_due(NOW, kind="day_close") is False
+    assert snapshot["daily_anchor_epochs"] == {
+        "day_close": epoch,
+        "day_open": epoch,
+    }
+    assert json.loads(cadence.path.read_text(encoding="utf-8"))["schema_version"] == (
+        "moon.heartbeat.cadence.v4"
+    )
+
+
+def test_heartbeat_engine_settles_exact_daily_anchor_kind(tmp_path):
+    judge = Judge(JudgeDecision(False, False, "silent"))
+    runtime, _controls, _bus, cadence = engine(
+        tmp_path,
+        judge,
+        Sink(),
+        kind_policies={
+            "day_open": _policy(profile="daily_anchor", host_only=True),
+            "day_close": _policy(profile="daily_anchor", host_only=True),
+        },
+    )
+
+    first = runtime.run(HeartbeatCandidate("day_open", {}))
+    second = runtime.run(HeartbeatCandidate("day_close", {}))
+
+    assert (first.status, second.status, judge.calls) == (
+        "skipped",
+        "skipped",
+        2,
+    )
+    assert cadence.snapshot()["daily_anchor_epochs"] == {
+        "day_close": "2026-08-22",
+        "day_open": "2026-08-22",
+    }
+
+
+def test_daily_anchor_gates_and_judge_failure_do_not_settle(tmp_path):
+    judge = Judge(error=RuntimeError("fixture"))
+    runtime, _controls, _bus, cadence = engine(
+        tmp_path,
+        judge,
+        Sink(),
+        kind_policies={
+            "day_open": _policy(profile="daily_anchor", host_only=True),
+        },
+    )
+    cadence.snooze(60, manual=True)
+
+    snoozed = runtime.run(HeartbeatCandidate("day_open", {}))
+    cadence.resume()
+    active = runtime.run(HeartbeatCandidate("day_open", {"active_chat": True}))
+    recent = runtime.run(
+        HeartbeatCandidate("day_open", {"recent_private_inbound_at": NOW})
+    )
+    failed = runtime.run(HeartbeatCandidate("day_open", {}))
+
+    assert [result.reason for result in (snoozed, active, recent)] == [
+        "manual_snooze",
+        "active_chat",
+        "recent_private_inbound",
+    ]
+    assert (failed.status, failed.reason, judge.calls) == (
+        "failed",
+        "judge_error:RuntimeError",
+        1,
+    )
+    assert cadence.snapshot()["daily_anchor_epochs"] == {}
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is True
+
+
+def test_daily_anchor_effect_failure_does_not_reopen_kind(tmp_path):
+    judge = Judge(JudgeDecision(False, True, "contact", "hello"))
+    runtime, _controls, _bus, cadence = engine(
+        tmp_path,
+        judge,
+        Sink(delivery_ok=False),
+        kind_policies={
+            "day_open": _policy(profile="daily_anchor", host_only=True),
+            "day_close": _policy(profile="daily_anchor", host_only=True),
+        },
+    )
+
+    failed = runtime.run(HeartbeatCandidate("day_open", {}))
+    duplicate = runtime.run(HeartbeatCandidate("day_open", {}))
+
+    assert (failed.status, failed.reason) == ("failed", "effect_failed")
+    assert (duplicate.status, duplicate.reason_code, judge.calls) == (
+        "neutral",
+        HeartbeatReasonCode.NO_EVENT,
+        1,
+    )
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is False
+    assert cadence.daily_anchor_due(NOW, kind="day_close") is True
+
+
+@pytest.mark.parametrize(
+    "schema_version",
+    (
+        "moon.heartbeat.cadence.v1",
+        "moon.heartbeat.cadence.v2",
+        "moon.heartbeat.cadence.v3",
+    ),
+)
+def test_legacy_daily_anchor_completion_is_a_migrated_wildcard(
+    tmp_path, schema_version
+):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW, anchor_hour=6)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": schema_version,
+                "daily_anchor_epoch": "2026-08-22",
+                "daily_anchor_completed": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is False
+    assert cadence.daily_anchor_due(NOW, kind="day_close") is False
+    assert cadence.snapshot(now=NOW)["daily_anchor_legacy_epoch"] == "2026-08-22"
+
+    cadence.mark_daily_anchor(
+        "2026-08-23", kind="day_open", now=NOW + timedelta(days=1)
+    )
+    snapshot = cadence.snapshot(now=NOW + timedelta(days=1))
+
+    assert snapshot["daily_anchor_epochs"] == {"day_open": "2026-08-23"}
+    assert cadence.daily_anchor_due(NOW + timedelta(days=1), kind="day_close") is True
+    assert json.loads(cadence.path.read_text(encoding="utf-8"))["schema_version"] == (
+        "moon.heartbeat.cadence.v4"
+    )
+
+
+def test_daily_anchor_mapping_validation_fails_closed(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.heartbeat.cadence.v4",
+                "daily_anchor_epochs": {"Day_Open": "2026-08-22"},
+                "daily_anchor_legacy_epoch": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(StateError, match="daily anchor state"):
+        cadence.daily_anchor_due(NOW, kind="day_open")
+
+    for fields in (
+        {
+            "daily_anchor_epochs": {
+                f"kind_{index}": "2026-08-22" for index in range(129)
+            },
+            "daily_anchor_legacy_epoch": None,
+        },
+        {
+            "daily_anchor_epochs": {},
+            "daily_anchor_legacy_epoch": None,
+            "daily_anchor_epoch": "2026-08-22",
+            "daily_anchor_completed": True,
+        },
+        {
+            "daily_anchor_epochs": {},
+            "daily_anchor_legacy_epoch": None,
+            "daily_anchor_unknown": True,
+        },
+    ):
+        cadence.path.write_text(
+            json.dumps({"schema_version": "moon.heartbeat.cadence.v4", **fields}),
+            encoding="utf-8",
+        )
+        with pytest.raises(StateError):
+            cadence.daily_anchor_due(NOW, kind="day_open")
+
+    with pytest.raises(ValueError, match="strict ISO date"):
+        cadence.mark_judge(
+            now=NOW,
+            next_judge_at=NOW + timedelta(hours=1),
+            anchor_epoch="2026-8-22",
+            anchor_kind="day_open",
+        )
+
+
+def test_cadence_observer_projects_exact_anchor_kinds(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.heartbeat.cadence.v4",
+                "daily_anchor_epochs": {
+                    "day_open": "2026-08-22",
+                    "day_close": "2026-08-21",
+                },
+                "daily_anchor_legacy_epoch": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    facts = {
+        fact.key: fact
+        for fact in cadence.observer_status(target_date=NOW.date(), now=NOW)
+    }
+
+    assert facts["heartbeat:anchor:day_open"].code == "heartbeat_anchor_completed"
+    assert "completion:exact" in facts["heartbeat:anchor:day_open"].refs
+    assert facts["heartbeat:anchor:day_close"].code == (
+        "heartbeat_anchor_outside_target"
+    )
 
 
 def test_queued_effect_is_pending_and_duplicate_reuses_intent(tmp_path):
@@ -1599,6 +1829,8 @@ def test_cadence_observer_marks_stale_anchor_outside_target_without_conclusion(
     assert "completed" not in anchor.code
     assert "pending" not in anchor.code
     assert "missed" not in anchor.code
+    assert "migration:legacy" in anchor.refs
+    assert anchor.counts["legacy"] == 1
     assert (cadence.path.read_bytes(), cadence.path.stat().st_mtime_ns) == before
     assert not cadence.lock_path.exists()
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -120,6 +120,46 @@ class PathlessCadence:
         return NOW
 
 
+class LegacyDailyAnchorCadence:
+    """Minimal pre-kind cadence port used by host compatibility tests."""
+
+    def __init__(self, *, due_error=None, mark_error=None):
+        self.due_error = due_error
+        self.mark_error = mark_error
+        self.due_calls = 0
+        self.mark_calls = 0
+        self.anchor_epochs = []
+
+    def blocked(self, _kind):
+        return False, "open"
+
+    def clock(self):
+        return NOW
+
+    def daily_anchor_due(self, _now=None):
+        self.due_calls += 1
+        if self.due_error is not None:
+            raise self.due_error
+        return True
+
+    def daily_anchor_epoch(self, _now=None):
+        return "2026-08-22"
+
+    def mark_judge(
+        self,
+        *,
+        now=None,
+        next_judge_at=None,
+        cadence_minutes=None,
+        anchor_epoch=None,
+    ):
+        self.mark_calls += 1
+        self.anchor_epochs.append(anchor_epoch)
+        if self.mark_error is not None:
+            raise self.mark_error
+        return now
+
+
 class PathlessControls:
     @property
     def ledger(self):
@@ -930,6 +970,56 @@ def test_heartbeat_engine_settles_exact_daily_anchor_kind(tmp_path):
     }
 
 
+def test_heartbeat_engine_supports_pre_kind_injected_cadence_port(tmp_path):
+    cadence = LegacyDailyAnchorCadence()
+    judge = Judge(JudgeDecision(False, False, "silent"))
+    runtime = HeartbeatEngine(
+        bus=EventBus(tmp_path, clock=lambda: NOW),
+        controls=ControlStore(tmp_path, clock=lambda: NOW),
+        cadence=cadence,
+        judge=judge,
+        sink=Sink(),
+        locks=FakeLocks(),
+        kind_policies={
+            "day_open": _policy(profile="daily_anchor", host_only=True),
+        },
+    )
+
+    result = runtime.run(HeartbeatCandidate("day_open", {}))
+
+    assert (result.status, result.reason) == ("skipped", "silent")
+    assert (cadence.due_calls, cadence.mark_calls, judge.calls) == (1, 1, 1)
+    assert cadence.anchor_epochs == ["2026-08-22"]
+
+
+@pytest.mark.parametrize("failure_port", ["due", "mark"])
+def test_injected_cadence_internal_type_error_is_not_retried(tmp_path, failure_port):
+    error = TypeError("cadence internal fixture")
+    cadence = LegacyDailyAnchorCadence(
+        due_error=error if failure_port == "due" else None,
+        mark_error=error if failure_port == "mark" else None,
+    )
+    judge = Judge(JudgeDecision(False, False, "silent"))
+    runtime = HeartbeatEngine(
+        bus=EventBus(tmp_path, clock=lambda: NOW),
+        controls=ControlStore(tmp_path, clock=lambda: NOW),
+        cadence=cadence,
+        judge=judge,
+        sink=Sink(),
+        locks=FakeLocks(),
+        kind_policies={
+            "day_open": _policy(profile="daily_anchor", host_only=True),
+        },
+    )
+
+    result = runtime.run(HeartbeatCandidate("day_open", {}))
+
+    assert (result.status, result.reason) == ("failed", "cadence_state_error")
+    assert cadence.due_calls == 1
+    assert cadence.mark_calls == (0 if failure_port == "due" else 1)
+    assert judge.calls == (0 if failure_port == "due" else 1)
+
+
 def test_daily_anchor_manual_snooze_bypass_is_explicit_per_kind(tmp_path):
     judge = Judge(JudgeDecision(False, False, "silent"))
     runtime, _controls, _bus, cadence = engine(
@@ -1061,6 +1151,66 @@ def test_legacy_daily_anchor_completion_is_a_migrated_wildcard(
     assert cadence.daily_anchor_due(NOW + timedelta(days=1), kind="day_close") is True
     assert json.loads(cadence.path.read_text(encoding="utf-8"))["schema_version"] == (
         "moon.heartbeat.cadence.v4"
+    )
+
+
+def test_legacy_anchor_without_completion_fails_closed_without_rewrite(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.heartbeat.cadence.v3",
+                "daily_anchor_epoch": "2026-08-22",
+            }
+        ),
+        encoding="utf-8",
+    )
+    before = cadence.path.read_bytes(), cadence.path.stat().st_mtime_ns
+
+    with pytest.raises(StateError, match="daily anchor state"):
+        cadence.daily_anchor_due(NOW, kind="day_open")
+    with pytest.raises(StateError, match="daily anchor state"):
+        cadence.snooze(60, manual=True)
+    facts = cadence.observer_status(target_date=NOW.date(), now=NOW)
+
+    assert len(facts) == 1
+    assert facts[0].state == "current"
+    assert "integrity" in facts[0].code
+    assert (cadence.path.read_bytes(), cadence.path.stat().st_mtime_ns) == before
+
+
+def test_legacy_incomplete_anchor_migrates_to_empty_exact_state(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.heartbeat.cadence.v3",
+                "daily_anchor_epoch": "2026-08-22",
+                "daily_anchor_completed": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cadence.snooze(60, manual=True)
+    persisted = json.loads(cadence.path.read_text(encoding="utf-8"))
+
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is True
+    assert persisted["schema_version"] == "moon.heartbeat.cadence.v4"
+    assert persisted["daily_anchor_epochs"] == {}
+    assert persisted["daily_anchor_legacy_epoch"] is None
+
+
+def test_legacy_snapshot_completion_remains_true_across_epoch_boundary(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW, anchor_hour=6)
+    cadence.mark_daily_anchor("2026-08-22", kind="daily_anchor", now=NOW)
+
+    snapshot = cadence.snapshot(now=NOW + timedelta(days=1))
+
+    assert snapshot["daily_anchor_epoch"] == "2026-08-22"
+    assert snapshot["daily_anchor_completed"] is True
+    assert (
+        cadence.daily_anchor_due(NOW + timedelta(days=1), kind="daily_anchor") is True
     )
 
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -123,10 +123,12 @@ class PathlessCadence:
 class LegacyDailyAnchorCadence:
     """Minimal pre-kind cadence port used by host compatibility tests."""
 
-    def __init__(self, *, due_error=None, mark_error=None):
+    def __init__(self, *, due_error=None, epoch_error=None, mark_error=None):
         self.due_error = due_error
+        self.epoch_error = epoch_error
         self.mark_error = mark_error
         self.due_calls = 0
+        self.epoch_calls = 0
         self.mark_calls = 0
         self.anchor_epochs = []
 
@@ -143,6 +145,9 @@ class LegacyDailyAnchorCadence:
         return True
 
     def daily_anchor_epoch(self, _now=None):
+        self.epoch_calls += 1
+        if self.epoch_error is not None:
+            raise self.epoch_error
         return "2026-08-22"
 
     def mark_judge(
@@ -988,24 +993,39 @@ def test_heartbeat_engine_supports_pre_kind_injected_cadence_port(tmp_path):
     result = runtime.run(HeartbeatCandidate("day_open", {}))
 
     assert (result.status, result.reason) == ("skipped", "silent")
-    assert (cadence.due_calls, cadence.mark_calls, judge.calls) == (1, 1, 1)
+    assert (
+        cadence.due_calls,
+        cadence.epoch_calls,
+        cadence.mark_calls,
+        judge.calls,
+    ) == (
+        1,
+        1,
+        1,
+        1,
+    )
     assert cadence.anchor_epochs == ["2026-08-22"]
 
 
-@pytest.mark.parametrize("failure_port", ["due", "mark"])
-def test_injected_cadence_internal_type_error_is_not_retried(tmp_path, failure_port):
-    error = TypeError("cadence internal fixture")
+@pytest.mark.parametrize("error_type", [TypeError, AttributeError])
+@pytest.mark.parametrize("failure_port", ["due", "epoch", "mark"])
+def test_injected_cadence_internal_error_fails_closed(
+    tmp_path, failure_port, error_type
+):
+    error = error_type("cadence internal fixture")
     cadence = LegacyDailyAnchorCadence(
         due_error=error if failure_port == "due" else None,
+        epoch_error=error if failure_port == "epoch" else None,
         mark_error=error if failure_port == "mark" else None,
     )
-    judge = Judge(JudgeDecision(False, False, "silent"))
+    judge = Judge(JudgeDecision(True, True, "contact", "hello"))
+    sink = Sink()
     runtime = HeartbeatEngine(
         bus=EventBus(tmp_path, clock=lambda: NOW),
         controls=ControlStore(tmp_path, clock=lambda: NOW),
         cadence=cadence,
         judge=judge,
-        sink=Sink(),
+        sink=sink,
         locks=FakeLocks(),
         kind_policies={
             "day_open": _policy(profile="daily_anchor", host_only=True),
@@ -1016,8 +1036,10 @@ def test_injected_cadence_internal_type_error_is_not_retried(tmp_path, failure_p
 
     assert (result.status, result.reason) == ("failed", "cadence_state_error")
     assert cadence.due_calls == 1
-    assert cadence.mark_calls == (0 if failure_port == "due" else 1)
+    assert cadence.epoch_calls == (0 if failure_port == "due" else 1)
+    assert cadence.mark_calls == (1 if failure_port == "mark" else 0)
     assert judge.calls == (0 if failure_port == "due" else 1)
+    assert (sink.deliveries, sink.wakes) == (0, 0)
 
 
 def test_daily_anchor_manual_snooze_bypass_is_explicit_per_kind(tmp_path):
@@ -1154,13 +1176,21 @@ def test_legacy_daily_anchor_completion_is_a_migrated_wildcard(
     )
 
 
-def test_legacy_anchor_without_completion_fails_closed_without_rewrite(tmp_path):
+@pytest.mark.parametrize(
+    "anchor_fields",
+    [
+        {"daily_anchor_epoch": "2026-08-22"},
+        {"daily_anchor_epoch": None, "daily_anchor_completed": True},
+    ],
+    ids=["missing-completion", "completion-without-epoch"],
+)
+def test_legacy_ambiguous_anchor_fails_closed_without_rewrite(tmp_path, anchor_fields):
     cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW)
     cadence.path.write_text(
         json.dumps(
             {
                 "schema_version": "moon.heartbeat.cadence.v3",
-                "daily_anchor_epoch": "2026-08-22",
+                **anchor_fields,
             }
         ),
         encoding="utf-8",

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -930,6 +930,42 @@ def test_heartbeat_engine_settles_exact_daily_anchor_kind(tmp_path):
     }
 
 
+def test_daily_anchor_manual_snooze_bypass_is_explicit_per_kind(tmp_path):
+    judge = Judge(JudgeDecision(False, False, "silent"))
+    runtime, _controls, _bus, cadence = engine(
+        tmp_path,
+        judge,
+        Sink(),
+        kind_policies={
+            "day_open": _policy(
+                profile="daily_anchor",
+                host_only=True,
+                bypass=["manual_snooze"],
+            ),
+            "day_close": _policy(
+                profile="daily_anchor",
+                host_only=True,
+                bypass=["manual_snooze"],
+            ),
+        },
+    )
+    cadence.snooze(60, manual=True)
+
+    day_open = runtime.run(HeartbeatCandidate("day_open", {}))
+    day_close = runtime.run(HeartbeatCandidate("day_close", {}))
+
+    assert (day_open.status, day_open.reason) == ("skipped", "silent")
+    assert (day_close.status, day_close.reason, judge.calls) == (
+        "skipped",
+        "silent",
+        2,
+    )
+    assert cadence.snapshot()["daily_anchor_epochs"] == {
+        "day_close": "2026-08-22",
+        "day_open": "2026-08-22",
+    }
+
+
 def test_daily_anchor_gates_and_judge_failure_do_not_settle(tmp_path):
     judge = Judge(error=RuntimeError("fixture"))
     runtime, _controls, _bus, cadence = engine(
@@ -1026,6 +1062,61 @@ def test_legacy_daily_anchor_completion_is_a_migrated_wildcard(
     assert json.loads(cadence.path.read_text(encoding="utf-8"))["schema_version"] == (
         "moon.heartbeat.cadence.v4"
     )
+
+
+def test_v3_per_kind_transition_migrates_exact_kinds(tmp_path):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW, anchor_hour=6)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.heartbeat.cadence.v3",
+                "daily_anchor_epoch": "2026-08-22",
+                "daily_anchor_completed": True,
+                "daily_anchor_epochs": {"day_open": "2026-08-22"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cadence.daily_anchor_due(NOW, kind="day_open") is False
+    assert cadence.daily_anchor_due(NOW, kind="day_close") is True
+    assert cadence.snapshot(now=NOW)["daily_anchor_legacy_epoch"] is None
+
+    cadence.mark_daily_anchor("2026-08-22", kind="day_close", now=NOW)
+    persisted = json.loads(cadence.path.read_text(encoding="utf-8"))
+
+    assert persisted["schema_version"] == "moon.heartbeat.cadence.v4"
+    assert persisted["daily_anchor_epochs"] == {
+        "day_close": "2026-08-22",
+        "day_open": "2026-08-22",
+    }
+    assert "daily_anchor_epoch" not in persisted
+    assert "daily_anchor_completed" not in persisted
+
+
+@pytest.mark.parametrize(
+    "summary",
+    [
+        {"daily_anchor_epoch": "2026-08-21", "daily_anchor_completed": True},
+        {"daily_anchor_epoch": None, "daily_anchor_completed": False},
+        {"daily_anchor_epoch": "2026-08-22"},
+    ],
+)
+def test_v3_per_kind_transition_conflicts_fail_closed(tmp_path, summary):
+    cadence = HeartbeatCadence(tmp_path, clock=lambda: NOW)
+    cadence.path.write_text(
+        json.dumps(
+            {
+                "schema_version": "moon.heartbeat.cadence.v3",
+                "daily_anchor_epochs": {"day_open": "2026-08-22"},
+                **summary,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(StateError, match="daily anchor state"):
+        cadence.daily_anchor_due(NOW, kind="day_open")
 
 
 def test_daily_anchor_mapping_validation_fails_closed(tmp_path):

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -104,6 +104,48 @@ def test_pack_user_merge_provenance_and_redaction(monkeypatch, tmp_path):
     assert safe["model_routes"]["main"]["alias"] == "<redacted>"
 
 
+def test_companion_pack_accepts_kind_scoped_daily_anchor_mute_bypass(
+    monkeypatch, tmp_path
+):
+    _resource_fixture(
+        monkeypatch,
+        tmp_path,
+        name="companion",
+        overlay={
+            "modules": {"heartbeat": True},
+            "heartbeat": {
+                "kinds": {
+                    "day_open": {
+                        "enabled": True,
+                        "profile": "daily_anchor",
+                        "judge": "required",
+                        "host_only": True,
+                        "bypass": ["automatic_cooldown", "manual_snooze"],
+                    },
+                    "day_close": {
+                        "enabled": True,
+                        "profile": "daily_anchor",
+                        "judge": "required",
+                        "host_only": True,
+                        "bypass": ["automatic_cooldown", "manual_snooze"],
+                    },
+                }
+            },
+        },
+    )
+
+    config = resolve_config({}, "companion").effective_config
+
+    assert config["heartbeat"]["kinds"]["day_open"]["bypass"] == [
+        "automatic_cooldown",
+        "manual_snooze",
+    ]
+    assert config["heartbeat"]["kinds"]["day_close"]["bypass"] == [
+        "automatic_cooldown",
+        "manual_snooze",
+    ]
+
+
 def test_empty_mapping_replaces_pack_map_and_lists_are_literals(monkeypatch, tmp_path):
     _resource_fixture(
         monkeypatch,

--- a/tests/test_silence_backoff.py
+++ b/tests/test_silence_backoff.py
@@ -8,6 +8,7 @@ import pytest
 from moonbite_plugin.config import ConfigError, normalize_config
 from moonbite_plugin.heartbeat import (
     CADENCE_SCHEMA_V1,
+    CADENCE_SCHEMA_V4,
     HeartbeatCadence,
     HeartbeatSilenceReceipt,
 )
@@ -218,11 +219,12 @@ def test_v1_state_migrates_on_next_write(tmp_path):
         ),
         encoding="utf-8",
     )
-    assert cadence.snapshot()["schema_version"].endswith("v3")
+    assert cadence.snapshot()["schema_version"] == CADENCE_SCHEMA_V4
     cadence.apply_silence_backoff(receipt(), policy=POLICY)
-    assert json.loads(cadence.path.read_text(encoding="utf-8"))[
-        "schema_version"
-    ].endswith("v3")
+    assert (
+        json.loads(cadence.path.read_text(encoding="utf-8"))["schema_version"]
+        == CADENCE_SCHEMA_V4
+    )
 
 
 def test_unknown_policy_and_malformed_state_fail_closed(tmp_path):


### PR DESCRIPTION
## Summary

- store daily-anchor completion as a bounded per-kind epoch mapping
- pass the candidate kind through due checks and Judge settlement
- preserve legacy injected cadence ports that do not accept per-kind keywords without swallowing implementation errors
- migrate valid v1-v3 cadence state conservatively while failing closed on ambiguous legacy completion evidence
- preserve the legacy snapshot completion view across epoch boundaries
- project exact-kind and legacy migration evidence through snapshots and observer facts

This provides the generic foundation for independent morning and evening anchors. It does not add a scenario pack, scheduler, transport, or provider configuration.

## Lifecycle semantics

- a valid Judge decision, including explicit silence, settles only that kind and epoch
- control gates, Judge errors, malformed decisions, and cadence write failures do not settle the anchor
- effect failure remains owned by the effect ledger and does not reopen a completed Judge occurrence
- valid existing state migrates automatically; ambiguous legacy state fails closed without rewriting the source file
- the legacy `daily_anchor_epoch` and `daily_anchor_completed` snapshot fields represent only the default `daily_anchor` kind or migrated wildcard evidence; named per-kind completion is authoritative in `daily_anchor_epochs`

## Compatibility

Cadence writes upgrade valid legacy state to schema v4. Back up cadence state before the first v4 write. After v4 is written, do not point an older Moonbite binary at the same state directory.

## Validation

- `pytest`: 725 passed on the rebased combination with PR #11
- `compileall`, Ruff checks/formatting, and `git diff --check`
- pinned Hermes contract: 10 tools / 5 hooks
- clean install and clean wheel smoke against pinned Hermes
- wheel and sdist build plus artifact privacy scans
- full reachable-history privacy scan and verified public Git identity audit
- rebase range-diff confirmed all five reviewed PR patches remained equivalent
- no dependencies or Hermes upstream changes

Prerequisite for the companion vertical slice tracked by #5. This PR does not implement or partially satisfy #5 acceptance.

Refs #3