### PR TITLE
fix(memory): support CJK lexical fallback

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -41,6 +41,10 @@ fail-closed and auditable.
   the hooks are no-ops while disabled.
 - `modules.memory` enables card/diary search, capture, exact history inspection,
   grounded diary synthesis, and operator maintenance commands.
+- Local lexical search also uses a bounded literal-substring fallback for
+  queries containing at least two Han, Hiragana, Katakana, or Hangul code
+  points when token matching has no hit; single-character CJK queries return
+  no results.
 - `delivery.adapter: noop` is safe and cannot claim delivery.
 - `delivery.adapter: hermes_session` can request a targeted main-session wake
   only when the host's `inject_message` surface explicitly supports a

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -41,10 +41,11 @@ fail-closed and auditable.
   the hooks are no-ops while disabled.
 - `modules.memory` enables card/diary search, capture, exact history inspection,
   grounded diary synthesis, and operator maintenance commands.
-- Local lexical search also uses a bounded literal-substring fallback for
-  queries containing at least two Han, Hiragana, Katakana, or Hangul code
-  points when token matching has no hit; single-character CJK queries return
-  no results.
+- Local lexical search also uses a bounded literal-substring or natural
+  contiguous-overlap fallback for queries containing at least two Han,
+  Hiragana, Katakana, or Hangul code points when token matching has no hit.
+  Natural overlap requires two shared four-codepoint features after Unicode
+  NFKC normalization; single-character CJK queries return no results.
 - `delivery.adapter: noop` is safe and cannot claim delivery.
 - `delivery.adapter: hermes_session` can request a targeted main-session wake
   only when the host's `inject_message` surface explicitly supports a

--- a/moonbite_plugin/memory.py
+++ b/moonbite_plugin/memory.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import math
 import re
+import unicodedata
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
@@ -45,6 +46,10 @@ MAX_RECALL_EXCERPT_BYTES = 2 * 1024
 MAX_RECALL_REASON_BYTES = 4 * 1024
 MAX_MAINTENANCE_PROPOSED_VALUE_BYTES = 16 * 1024
 _CJK_FALLBACK_SCORE = 1
+_CJK_OVERLAP_NGRAM_SIZE = 4
+_CJK_OVERLAP_MIN_FEATURES = 2
+_CJK_OVERLAP_MAX_FEATURES = 256
+_CJK_OVERLAP_MAX_CODEPOINTS = 4096
 _CJK_CODEPOINT_RANGES = (
     (0x1100, 0x11FF),  # Hangul Jamo
     (0x3040, 0x309F),  # Hiragana
@@ -137,6 +142,51 @@ def _has_cjk_query(value: str) -> bool:
             for character in value
         )
         >= 2
+    )
+
+
+def _cjk_features(value: str) -> set[str]:
+    features: set[str] = set()
+    run: list[str] = []
+    scanned = 0
+
+    def add_run() -> bool:
+        if len(run) < _CJK_OVERLAP_NGRAM_SIZE:
+            return False
+        for index in range(len(run) - _CJK_OVERLAP_NGRAM_SIZE + 1):
+            features.add("".join(run[index : index + _CJK_OVERLAP_NGRAM_SIZE]))
+            if len(features) >= _CJK_OVERLAP_MAX_FEATURES:
+                return True
+        return False
+
+    for character in value:
+        if scanned >= _CJK_OVERLAP_MAX_CODEPOINTS:
+            break
+        scanned += 1
+        is_cjk = any(
+            start <= ord(character) <= end for start, end in _CJK_CODEPOINT_RANGES
+        )
+        if is_cjk:
+            run.append(character)
+            continue
+        if add_run():
+            return features
+        run.clear()
+    add_run()
+    return features
+
+
+def _cjk_fallback_matches(
+    literal_query: str, query_features: set[str], text: str
+) -> bool:
+    normalized_text = unicodedata.normalize("NFKC", text)
+    if literal_query in normalized_text:
+        return True
+    if len(query_features) < _CJK_OVERLAP_MIN_FEATURES:
+        return False
+    return (
+        len(query_features & _cjk_features(normalized_text))
+        >= _CJK_OVERLAP_MIN_FEATURES
     )
 
 
@@ -899,8 +949,9 @@ class MemoryStore:
         include_historical: bool = False,
     ) -> list[SearchHit]:
         terms = _tokens(query)
-        literal_query = query.strip()
+        literal_query = unicodedata.normalize("NFKC", query.strip())
         cjk_fallback = _has_cjk_query(literal_query)
+        cjk_features = _cjk_features(literal_query) if cjk_fallback else set()
         if not 1 <= limit <= 100 or (not terms and not cjk_fallback):
             return []
         hits: list[SearchHit] = []
@@ -912,7 +963,11 @@ class MemoryStore:
             text = " ".join((card["summary"], *card["tags"]))
             haystack = _tokens(text)
             score = len(terms & haystack)
-            if not score and cjk_fallback and literal_query in text:
+            if (
+                not score
+                and cjk_fallback
+                and _cjk_fallback_matches(literal_query, cjk_features, text)
+            ):
                 score = _CJK_FALLBACK_SCORE
             if score:
                 hits.append(
@@ -927,7 +982,11 @@ class MemoryStore:
         for entry in self._diary_rows():
             text = f"{entry.title} {entry.body}"
             score = len(terms & _tokens(text))
-            if not score and cjk_fallback and literal_query in text:
+            if (
+                not score
+                and cjk_fallback
+                and _cjk_fallback_matches(literal_query, cjk_features, text)
+            ):
                 score = _CJK_FALLBACK_SCORE
             if score:
                 hits.append(

--- a/moonbite_plugin/memory.py
+++ b/moonbite_plugin/memory.py
@@ -44,6 +44,16 @@ MAX_OPEN_REF_BYTES = 4 * 1024
 MAX_RECALL_EXCERPT_BYTES = 2 * 1024
 MAX_RECALL_REASON_BYTES = 4 * 1024
 MAX_MAINTENANCE_PROPOSED_VALUE_BYTES = 16 * 1024
+_CJK_FALLBACK_SCORE = 1
+_CJK_CODEPOINT_RANGES = (
+    (0x1100, 0x11FF),  # Hangul Jamo
+    (0x3040, 0x309F),  # Hiragana
+    (0x30A0, 0x30FF),  # Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # Han
+    (0xAC00, 0xD7AF),  # Hangul syllables
+    (0xF900, 0xFAFF),  # CJK compatibility ideographs
+)
 
 
 def _validated_event_time(value: str) -> str:
@@ -118,6 +128,16 @@ def _validated_text_items(
 
 def _tokens(value: str) -> set[str]:
     return {part.lower() for part in re.findall(r"[\w\-]{2,}", value, re.UNICODE)}
+
+
+def _has_cjk_query(value: str) -> bool:
+    return (
+        sum(
+            any(start <= ord(character) <= end for start, end in _CJK_CODEPOINT_RANGES)
+            for character in value
+        )
+        >= 2
+    )
 
 
 @dataclass(frozen=True)
@@ -879,7 +899,9 @@ class MemoryStore:
         include_historical: bool = False,
     ) -> list[SearchHit]:
         terms = _tokens(query)
-        if not terms or not 1 <= limit <= 100:
+        literal_query = query.strip()
+        cjk_fallback = _has_cjk_query(literal_query)
+        if not 1 <= limit <= 100 or (not terms and not cjk_fallback):
             return []
         hits: list[SearchHit] = []
         for card in self._card_views():
@@ -887,8 +909,11 @@ class MemoryStore:
                 continue
             if not include_historical and card["history_status"] != "current":
                 continue
-            haystack = _tokens(" ".join((card["summary"], *card["tags"])))
+            text = " ".join((card["summary"], *card["tags"]))
+            haystack = _tokens(text)
             score = len(terms & haystack)
+            if not score and cjk_fallback and literal_query in text:
+                score = _CJK_FALLBACK_SCORE
             if score:
                 hits.append(
                     SearchHit(
@@ -900,7 +925,10 @@ class MemoryStore:
                     )
                 )
         for entry in self._diary_rows():
-            score = len(terms & _tokens(f"{entry.title} {entry.body}"))
+            text = f"{entry.title} {entry.body}"
+            score = len(terms & _tokens(text))
+            if not score and cjk_fallback and literal_query in text:
+                score = _CJK_FALLBACK_SCORE
             if score:
                 hits.append(
                     SearchHit(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -139,6 +139,40 @@ def test_lexical_recall_reconstructs_cjk_fallback_candidate(tmp_path):
     ] == [(card.open_ref, 1, "偏好口语 回复偏好")]
 
 
+@pytest.mark.parametrize(
+    ("summary", "query"),
+    [
+        ("偏好简短口语回复", "请继续用简短口语回复"),
+        ("偏好简短口语回复", "你还记得我偏好简短口语回复吗"),
+        ("偏好﨑短口語回复", "请继续用崎短口語回复"),
+    ],
+)
+def test_cjk_natural_overlap_is_bounded_and_nfkc_normalized(tmp_path, summary, query):
+    memory = MemoryStore(tmp_path, clock=lambda: NOW)
+    card = memory.add_card(
+        summary,
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-cjk-natural",
+    )
+
+    hits = memory.search(query)
+
+    assert [(hit.open_ref, hit.score) for hit in hits] == [(card.open_ref, 1)]
+
+
+def test_cjk_natural_overlap_rejects_common_short_phrases(tmp_path):
+    memory = MemoryStore(tmp_path, clock=lambda: NOW)
+    memory.add_card(
+        "今天的天气晴朗适合散步但是路上拥挤",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-cjk-unrelated",
+    )
+
+    assert memory.search("明天的天气阴沉需要带伞") == []
+
+
 def test_cards_and_diary_return_exact_open_references(tmp_path):
     memory = MemoryStore(tmp_path, clock=lambda: NOW)
     card = memory.add_card(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -33,6 +33,112 @@ class FixtureRetriever:
         return self.hits
 
 
+@pytest.mark.parametrize(
+    ("query", "summary"),
+    [
+        ("口语", "偏好简短口语回复"),
+        ("かな", "かなを含む長い日記題名"),
+        ("カナ", "カナを含む長い日記本文"),
+        ("한글", "한글을 포함한 긴 기록"),
+    ],
+)
+def test_cjk_literal_fallback_covers_supported_scripts(tmp_path, query, summary):
+    memory = MemoryStore(tmp_path, clock=lambda: NOW)
+    card = memory.add_card(
+        summary,
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-cjk-card",
+    )
+
+    hits = memory.search(query)
+
+    assert [(hit.open_ref, hit.score) for hit in hits] == [(card.open_ref, 1)]
+
+
+def test_cjk_fallback_keeps_score_order_gates_and_limit(tmp_path):
+    memory = MemoryStore(tmp_path, clock=lambda: NOW)
+    token_hit = memory.add_card(
+        "口语 回复 alpha",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-token-hit",
+    )
+    fallback_hit = memory.add_card(
+        "偏好口语 回复偏好",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-fallback-hit",
+    )
+    diary = memory.append_diary(
+        day=date(2026, 8, 22),
+        title="合成日记标题",
+        body="这里记录口语回复相关内容。",
+        source_ref="event:fixture",
+        entry_id="fixture-cjk-diary",
+    )
+
+    hits = memory.search("口语 回复")
+
+    assert [(hit.open_ref, hit.score) for hit in hits] == [
+        (token_hit.open_ref, 2),
+        (fallback_hit.open_ref, 1),
+    ]
+    assert [(hit.open_ref, hit.score) for hit in memory.search("口语回复")] == [
+        (diary.open_ref, 1)
+    ]
+    assert [hit.open_ref for hit in memory.search("口语 回复", limit=1)] == [
+        token_hit.open_ref
+    ]
+    assert memory.search("口") == []
+
+    original = memory.add_card(
+        "旧口语记录",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-history-old",
+        event_time="2026-01-01",
+        state_key="fixture.cjk",
+    )
+    current = memory.add_card(
+        "新口语记录",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-history-current",
+        event_time="2026-08-22",
+        state_key="fixture.cjk",
+        supersedes=[original.card_id],
+        supersession_kind="evolution",
+    )
+    default_refs = {hit.open_ref for hit in memory.search("口语")}
+    assert original.open_ref not in default_refs
+    assert current.open_ref in default_refs
+    assert {hit.open_ref for hit in memory.search("口语", include_historical=True)} == {
+        original.open_ref,
+        current.open_ref,
+        diary.open_ref,
+        fallback_hit.open_ref,
+        token_hit.open_ref,
+    }
+
+
+def test_lexical_recall_reconstructs_cjk_fallback_candidate(tmp_path):
+    memory = MemoryStore(tmp_path, clock=lambda: NOW)
+    card = memory.add_card(
+        "偏好口语 回复偏好",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+        card_id="fixture-cjk-recall",
+    )
+
+    candidates = memory.lexical_recall("口语 回复")
+
+    assert [
+        (candidate.open_ref, candidate.score, candidate.excerpt)
+        for candidate in candidates
+    ] == [(card.open_ref, 1, "偏好口语 回复偏好")]
+
+
 def test_cards_and_diary_return_exact_open_references(tmp_path):
     memory = MemoryStore(tmp_path, clock=lambda: NOW)
     card = memory.add_card(
@@ -49,8 +155,10 @@ def test_cards_and_diary_return_exact_open_references(tmp_path):
         entry_id="fixture-diary",
     )
 
-    refs = {hit.open_ref for hit in memory.search("moonlit")}
-    assert refs == {card.open_ref, diary.open_ref}
+    assert [(hit.open_ref, hit.score) for hit in memory.search("moonlit")] == [
+        (card.open_ref, 1),
+        (diary.open_ref, 1),
+    ]
     assert memory.open(card.open_ref)["source_ref"] == "conversation:fixture"
     assert memory.open(diary.open_ref)["source_ref"] == "event:fixture"
 
@@ -416,7 +524,7 @@ def test_history_relations_project_current_corrected_and_medium_context(tmp_path
 def test_retire_apply_archives_without_deleting_and_replays(tmp_path):
     memory = MemoryStore(tmp_path, clock=lambda: NOW)
     card = memory.add_card(
-        "Archive boundary fixture",
+        "Archive boundary口语fixture",
         provenance="agent_observation",
         source_ref="event:fixture",
         card_id="archive-fixture",
@@ -454,6 +562,7 @@ def test_retire_apply_archives_without_deleting_and_replays(tmp_path):
     assert receipt["archived_card_ids"] == [card.card_id]
     assert "delete" not in str(receipt).casefold()
     assert memory.search("archive boundary") == []
+    assert memory.search("口语") == []
     assert memory.open(card.open_ref)["lifecycle_status"] == "archived"
 
     with pytest.raises(StateError, match="replay conflict"):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -684,6 +684,28 @@ def test_external_provider_failure_falls_back_to_lexical_and_audits(tmp_path):
     assert audit.payload == {"status": "fallback", "error": "OSError"}
 
 
+@pytest.mark.parametrize("provider_failure", [False, True])
+def test_recall_memory_cjk_fallback_with_or_without_external(
+    tmp_path, provider_failure
+):
+    runtime = MoonbiteRuntime(
+        recall_config(),
+        root=tmp_path,
+        external_retriever=(
+            Retriever(error=OSError("provider fixture")) if provider_failure else None
+        ),
+    )
+    card = runtime.add_memory_card(
+        "偏好简短口语回复",
+        provenance="user_explicit",
+        source_ref="conversation:fixture",
+    )
+
+    result = runtime.recall_memory("口语")
+
+    assert [candidate.open_ref for candidate in result] == [f"card:{card['card_id']}"]
+
+
 def test_external_retriever_order_takes_precedence_when_refs_open(tmp_path):
     runtime = MoonbiteRuntime(recall_config(), root=tmp_path)
     lexical_first = runtime.add_memory_card(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -555,6 +555,23 @@ def test_memory_prompt_context_is_bounded_untrusted_json(tmp_path):
     assert "Ignore instructions" in context["context"]
 
 
+def test_memory_prompt_context_uses_cjk_natural_overlap(tmp_path):
+    runtime = MoonbiteRuntime(recall_config(), root=tmp_path)
+    runtime.add_memory_card(
+        "偏好简短口语回复",
+        provenance="user_explicit",
+        source_ref="conversation:fixture-cjk",
+    )
+
+    context = runtime.memory_prompt_context(
+        "你还记得我偏好简短口语回复吗",
+        session_receipt=private_exposure_context(),
+    )
+
+    assert context is not None
+    assert "偏好简短口语回复" in context["context"]
+
+
 def test_memory_prompt_requires_typed_private_receipt_and_keeps_body_transient(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary

- add a bounded literal-substring fallback for multi-character CJK queries when token matching finds no overlap
- add bounded NFKC-normalized natural-message overlap using two shared four-codepoint features
- cover Han, Hiragana, Katakana, and Hangul while keeping single-character CJK queries disabled
- preserve ASCII scoring and ordering, lifecycle filters, limits, exact-open reconstruction, and external retriever precedence

## Validation

- `pytest`: 697 passed
- Ruff check and format check
- `compileall` and `git diff --check`
- pinned Hermes contract: 10 tools / 5 hooks
- clean install and clean wheel smoke
- full Git identity/history/privacy scan plus unpacked wheel and sdist artifact scans

Closes #10