### PR TITLE
fix(session): preserve definitive host finalize evidence

### DIFF
--- a/moonbite_plugin/plugin.py
+++ b/moonbite_plugin/plugin.py
@@ -883,7 +883,7 @@ def register_runtime(
         runtime.record_session_hook("post_llm_call", kwargs, settled=True)
 
     def on_session_finalize(**kwargs: Any) -> None:
-        runtime.record_session_hook("on_session_finalize", kwargs)
+        runtime.record_hermes_session_finalize(kwargs)
 
     hook_handlers = {
         "pre_gateway_dispatch": pre_gateway_dispatch,

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -65,7 +65,7 @@ SUPPORTED_SESSION_HOOKS = frozenset(SESSION_HOOK_ORDER)
 DEFAULT_SESSION_HOOKS = frozenset(
     hook for hook in SUPPORTED_SESSION_HOOKS if hook != "pre_gateway_dispatch"
 )
-_DEFINITIVE_HERMES_FINALIZE_REASONS = frozenset({"session_expired"})
+_DEFINITIVE_HERMES_FINALIZE_REASONS = frozenset({"new_session", "session_expired"})
 SessionContextResolver = Callable[
     [str, Mapping[str, Any], frozenset[str]], SessionContext | None
 ]

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -65,6 +65,7 @@ SUPPORTED_SESSION_HOOKS = frozenset(SESSION_HOOK_ORDER)
 DEFAULT_SESSION_HOOKS = frozenset(
     hook for hook in SUPPORTED_SESSION_HOOKS if hook != "pre_gateway_dispatch"
 )
+_DEFINITIVE_HERMES_FINALIZE_REASONS = frozenset({"shutdown", "session_expired"})
 SessionContextResolver = Callable[
     [str, Mapping[str, Any], frozenset[str]], SessionContext | None
 ]
@@ -396,6 +397,7 @@ class MoonbiteRuntime:
         kwargs: Mapping[str, Any] | None = None,
         *,
         settled: bool = False,
+        _record_host_finalize: bool = False,
     ):
         """Map one public hook and append it to the injected session owner.
 
@@ -436,7 +438,10 @@ class MoonbiteRuntime:
                 # Internal/system events are never contact, even when a
                 # resolver is present.
                 return None
-            receipt = self.session.record_hook(context, hook, settled=settled)
+            if _record_host_finalize:
+                receipt = self.session.record_host_finalize(context)
+            else:
+                receipt = self.session.record_hook(context, hook, settled=settled)
         except SessionHookMappingError as exc:
             self._remember_session_hook_error(hook, exc)
             return None
@@ -456,6 +461,22 @@ class MoonbiteRuntime:
             raise
         self._last_session_hook_error = None
         return receipt
+
+    def record_hermes_session_finalize(
+        self, kwargs: Mapping[str, Any] | None = None
+    ) -> SessionHookReceipt | None:
+        """Route only definitive Hermes finalization reasons to host close."""
+
+        payload = {} if kwargs is None else kwargs
+        reason = payload.get("reason")
+        definitive = (
+            type(reason) is str and reason in _DEFINITIVE_HERMES_FINALIZE_REASONS
+        )
+        return self.record_session_hook(
+            "on_session_finalize",
+            payload,
+            _record_host_finalize=definitive,
+        )
 
     def _local_reflection(self, context) -> dict[str, Any]:
         facts = dict(context.facts)

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -65,7 +65,7 @@ SUPPORTED_SESSION_HOOKS = frozenset(SESSION_HOOK_ORDER)
 DEFAULT_SESSION_HOOKS = frozenset(
     hook for hook in SUPPORTED_SESSION_HOOKS if hook != "pre_gateway_dispatch"
 )
-_DEFINITIVE_HERMES_FINALIZE_REASONS = frozenset({"shutdown", "session_expired"})
+_DEFINITIVE_HERMES_FINALIZE_REASONS = frozenset({"session_expired"})
 SessionContextResolver = Callable[
     [str, Mapping[str, Any], frozenset[str]], SessionContext | None
 ]
@@ -439,7 +439,13 @@ class MoonbiteRuntime:
                 # resolver is present.
                 return None
             if _record_host_finalize:
-                receipt = self.session.record_host_finalize(context)
+                record_host_finalize = getattr(
+                    self.session, "record_host_finalize", None
+                )
+                if callable(record_host_finalize):
+                    receipt = record_host_finalize(context)
+                else:
+                    receipt = self.session.record_hook(context, hook, settled=settled)
             else:
                 receipt = self.session.record_hook(context, hook, settled=settled)
         except SessionHookMappingError as exc:
@@ -469,6 +475,8 @@ class MoonbiteRuntime:
 
         payload = {} if kwargs is None else kwargs
         reason = payload.get("reason")
+        if type(reason) is str and reason == "shutdown":
+            return None
         definitive = (
             type(reason) is str and reason in _DEFINITIVE_HERMES_FINALIZE_REASONS
         )

--- a/moonbite_plugin/session.py
+++ b/moonbite_plugin/session.py
@@ -28,7 +28,9 @@ SESSION_LIFECYCLE_KIND = "hook"
 SESSION_TURN_TERMINAL_SCHEMA = "moon.session.turn_terminal.v1"
 SESSION_TURN_TERMINAL_KIND = "turn_terminal"
 TURN_TERMINAL_OUTCOMES = frozenset({"abandoned"})
-TURN_TERMINAL_REASONS = frozenset({"superseded_by_new_pre", "operator_repair"})
+TURN_TERMINAL_REASONS = frozenset(
+    {"superseded_by_new_pre", "operator_repair", "host_session_finalized"}
+)
 
 HOOK_ORDER = (
     "pre_gateway_dispatch",
@@ -291,7 +293,7 @@ class SessionTurnTerminal:
             if self.superseded_by_turn_id == self.turn_id:
                 raise ValueError("turn cannot supersede itself")
         elif self.superseded_by_turn_id is not None:
-            raise ValueError("operator repair cannot name a successor turn")
+            raise ValueError("only a superseded terminal can name a successor turn")
         if not isinstance(self.observed_at, datetime):
             raise TypeError("observed_at must be a datetime")
         object.__setattr__(self, "observed_at", as_utc(self.observed_at))
@@ -958,6 +960,67 @@ class SessionLifecycleStore:
             self._apply_terminal(state, terminal)
             self.ledger.append(terminal.to_row())
             return self._terminal_receipt(terminal, state, deduplicated=False)
+
+    def record_host_finalize(self, context: SessionContext) -> SessionHookReceipt:
+        """Finalize a session using already-validated host termination evidence.
+
+        The host adapter, rather than the portable lifecycle core, decides when
+        a finalization is authoritative.  Under the normal mutation lock we
+        apply the optional abandonment and finalize callback to the in-memory
+        state before appending either row.  If the second append fails, replay
+        of the first row leaves the finalize callback as the only operation to
+        complete on retry.
+        """
+
+        self._validate_inputs(context, "on_session_finalize", False)
+        callback = _Callback(
+            context=context,
+            hook="on_session_finalize",
+            settled=False,
+            event_id=new_id("session_hook"),
+        )
+        with file_lock(self.mutation_lock):
+            states = self._replay_unlocked()
+            state = states.get(context.lifecycle_id)
+            if state is None:
+                state = self._new_state(context)
+                states[context.lifecycle_id] = state
+
+            existing = state.callbacks.get(callback.key)
+            if existing is not None:
+                self._apply(state, callback, allow_duplicate=True)
+                callback = existing
+                deduplicated = True
+            else:
+                terminal: SessionTurnTerminal | None = None
+                if state.current_turn_id is not None:
+                    terminal = SessionTurnTerminal(
+                        schema_version=SESSION_TURN_TERMINAL_SCHEMA,
+                        event_id=new_id("session_turn_terminal"),
+                        session_id=state.session_id,
+                        lifecycle_id=state.lifecycle_id,
+                        turn_id=state.current_turn_id,
+                        outcome="abandoned",
+                        reason="host_session_finalized",
+                        superseded_by_turn_id=None,
+                        observed_at=context.observed_at,
+                    )
+                    self._apply_terminal(state, terminal)
+
+                # Apply every semantic check before making either durable
+                # append.  A rejected finalize therefore cannot leave a
+                # terminal row behind.
+                self._apply(state, callback, allow_duplicate=True)
+                if terminal is not None:
+                    self.ledger.append(terminal.to_row())
+                self.ledger.append(callback.to_row())
+                deduplicated = False
+
+            return self._receipt(
+                callback,
+                state,
+                deduplicated=deduplicated,
+            )
 
     def snapshots(self) -> tuple[SessionLifecycleSnapshot, ...]:
         with file_lock(self.mutation_lock):

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -586,7 +586,42 @@ def test_plugin_shutdown_finalize_is_noop_and_successor_pre_repairs_old_turn(tmp
     ] == ["superseded_by_new_pre"]
 
 
-@pytest.mark.parametrize("reason", (None, "new_session", "other", ["shutdown"]))
+def test_plugin_new_session_finalize_closes_old_session_only(tmp_path):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="session-old")
+    context.hooks["pre_llm_call"](session_id="session-old", turn_id="turn-old")
+    context.hooks["on_session_finalize"](
+        session_id="session-old",
+        reason="new_session",
+        old_session_id="session-old",
+        new_session_id="session-new",
+    )
+
+    old_snapshot = components.session.snapshot("session-old")
+    assert old_snapshot is not None
+    assert old_snapshot.finalized is True
+    assert old_snapshot.open_turn_id is None
+    assert old_snapshot.settled_turn_ids == ()
+    assert old_snapshot.abandoned_turn_ids == ("turn-old",)
+    assert [
+        row["reason"]
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ["host_session_finalized"]
+
+    context.hooks["on_session_start"](session_id="session-new")
+    context.hooks["pre_llm_call"](session_id="session-new", turn_id="turn-new")
+    new_snapshot = components.session.snapshot("session-new")
+    assert new_snapshot is not None
+    assert new_snapshot.finalized is False
+    assert new_snapshot.open_turn_id == "turn-new"
+    assert new_snapshot.abandoned_turn_ids == ()
+
+
+@pytest.mark.parametrize("reason", (None, "other", ["shutdown"]))
 def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
     tmp_path, reason
 ):
@@ -606,7 +641,19 @@ def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
     assert all(row["kind"] != "turn_terminal" for row in rows)
 
 
-def test_session_expired_falls_back_for_legacy_session_owner(tmp_path):
+@pytest.mark.parametrize(
+    ("reason", "extra"),
+    (
+        ("session_expired", {}),
+        (
+            "new_session",
+            {"old_session_id": "session-fixture", "new_session_id": "session-new"},
+        ),
+    ),
+)
+def test_definitive_finalize_falls_back_for_legacy_session_owner(
+    tmp_path, reason, extra
+):
     components, _locks, _bus = injected_bundle(tmp_path / "host")
     underlying_session = components.session
     legacy_session = SimpleNamespace(
@@ -622,7 +669,7 @@ def test_session_expired_falls_back_for_legacy_session_owner(tmp_path):
     context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-fixture")
     with pytest.raises(SessionLifecycleError, match="settled"):
         context.hooks["on_session_finalize"](
-            session_id="session-fixture", reason="session_expired"
+            session_id="session-fixture", reason=reason, **extra
         )
 
     rows = underlying_session.ledger.rows()

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -29,7 +29,12 @@ from moonbite_plugin.panel import PanelStore
 from moonbite_plugin.plugin import register
 from moonbite_plugin.runtime_core import EventBus
 from moonbite_plugin.service import MoonbiteRuntime
-from moonbite_plugin.session import HOOK_ORDER, SessionContext, SessionLifecycleStore
+from moonbite_plugin.session import (
+    HOOK_ORDER,
+    SessionContext,
+    SessionLifecycleError,
+    SessionLifecycleStore,
+)
 
 
 class RecordingLocks:
@@ -522,6 +527,56 @@ def test_registered_session_hooks_are_ordered_and_default_source_isolation(tmp_p
     assert "private body" not in components.session.ledger.path.read_text(
         encoding="utf-8"
     )
+
+
+@pytest.mark.parametrize(
+    ("reason", "complete"),
+    (("shutdown", False), ("session_expired", False), ("shutdown", True)),
+)
+def test_plugin_definitive_hermes_finalize_closes_open_turn(tmp_path, reason, complete):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="session-fixture")
+    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-fixture")
+    if complete:
+        context.hooks["post_llm_call"](
+            session_id="session-fixture", turn_id="turn-fixture"
+        )
+    context.hooks["on_session_finalize"](session_id="session-fixture", reason=reason)
+
+    snapshot = components.session.snapshot("session-fixture")
+    assert snapshot is not None
+    assert snapshot.finalized is True
+    assert snapshot.open_turn_id is None
+    assert snapshot.settled_turn_ids == (("turn-fixture",) if complete else ())
+    assert snapshot.abandoned_turn_ids == (() if complete else ("turn-fixture",))
+    assert [
+        row["reason"]
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ([] if complete else ["host_session_finalized"])
+
+
+@pytest.mark.parametrize("reason", (None, "new_session", "other", ["shutdown"]))
+def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
+    tmp_path, reason
+):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="session-fixture")
+    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-fixture")
+    with pytest.raises(SessionLifecycleError, match="settled"):
+        context.hooks["on_session_finalize"](
+            session_id="session-fixture", reason=reason
+        )
+
+    rows = components.session.ledger.rows()
+    assert len(rows) == 2
+    assert all(row["kind"] != "turn_terminal" for row in rows)
 
 
 def test_resolver_can_supply_authorized_private_gateway_context(tmp_path):

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -531,9 +531,9 @@ def test_registered_session_hooks_are_ordered_and_default_source_isolation(tmp_p
 
 @pytest.mark.parametrize(
     ("reason", "complete"),
-    (("shutdown", False), ("session_expired", False), ("shutdown", True)),
+    (("session_expired", False), ("session_expired", True)),
 )
-def test_plugin_definitive_hermes_finalize_closes_open_turn(tmp_path, reason, complete):
+def test_plugin_session_expired_finalize_closes_open_turn(tmp_path, reason, complete):
     components, _locks, _bus = injected_bundle(tmp_path / "host")
     context = RecordingContext()
     register(context, components=components)
@@ -559,6 +559,33 @@ def test_plugin_definitive_hermes_finalize_closes_open_turn(tmp_path, reason, co
     ] == ([] if complete else ["host_session_finalized"])
 
 
+def test_plugin_shutdown_finalize_is_noop_and_successor_pre_repairs_old_turn(tmp_path):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="session-fixture")
+    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-1")
+    context.hooks["on_session_finalize"](
+        session_id="session-fixture", reason="shutdown"
+    )
+    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-2")
+
+    snapshot = components.session.snapshot("session-fixture")
+    assert snapshot is not None
+    assert snapshot.finalized is False
+    assert snapshot.open_turn_id == "turn-2"
+    assert snapshot.abandoned_turn_ids == ("turn-1",)
+    assert [
+        row["hook"] for row in components.session.ledger.rows() if row["kind"] == "hook"
+    ] == ["on_session_start", "pre_llm_call", "pre_llm_call"]
+    assert [
+        row["reason"]
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ["superseded_by_new_pre"]
+
+
 @pytest.mark.parametrize("reason", (None, "new_session", "other", ["shutdown"]))
 def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
     tmp_path, reason
@@ -575,6 +602,30 @@ def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
         )
 
     rows = components.session.ledger.rows()
+    assert len(rows) == 2
+    assert all(row["kind"] != "turn_terminal" for row in rows)
+
+
+def test_session_expired_falls_back_for_legacy_session_owner(tmp_path):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    underlying_session = components.session
+    legacy_session = SimpleNamespace(
+        record_hook=underlying_session.record_hook,
+        snapshot=underlying_session.snapshot,
+        replay=underlying_session.replay,
+    )
+    components = replace(components, session=legacy_session)
+    context = RecordingContext()
+    register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="session-fixture")
+    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-fixture")
+    with pytest.raises(SessionLifecycleError, match="settled"):
+        context.hooks["on_session_finalize"](
+            session_id="session-fixture", reason="session_expired"
+        )
+
+    rows = underlying_session.ledger.rows()
     assert len(rows) == 2
     assert all(row["kind"] != "turn_terminal" for row in rows)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,6 +21,7 @@ from moonbite_plugin.session import (
 NOW = datetime(2026, 8, 24, 19, 0, tzinfo=UTC)
 ALL_HOOKS = frozenset(HOOK_ORDER)
 TURN_HOOKS = frozenset({"pre_llm_call", "post_llm_call"})
+FINALIZE_HOOKS = frozenset(HOOK_ORDER[1:])
 
 
 def context(
@@ -42,6 +43,28 @@ def context(
         observed_at=observed_at,
         fresh=fresh,
         supported_hooks=supported_hooks,
+    )
+
+
+def open_turn_store(root):
+    store = SessionLifecycleStore(root)
+    store.record_hook(
+        context("start", source_kind="session_start", supported_hooks=FINALIZE_HOOKS),
+        "on_session_start",
+    )
+    store.record_hook(
+        context("pre", turn_id="turn-1", supported_hooks=FINALIZE_HOOKS),
+        "pre_llm_call",
+    )
+    return store
+
+
+def finalize_context(*, observed_at=NOW):
+    return context(
+        "finalize",
+        source_kind="system",
+        supported_hooks=FINALIZE_HOOKS,
+        observed_at=observed_at,
     )
 
 
@@ -338,6 +361,118 @@ def test_finalize_rejects_unsettled_turn(tmp_path) -> None:
             context("finalize", source_kind="system"), "on_session_finalize"
         )
     assert len(store.ledger.rows()) == 3
+
+
+def test_host_finalize_abandons_open_turn_without_settling(tmp_path) -> None:
+    store = open_turn_store(tmp_path)
+
+    receipt = store.record_host_finalize(finalize_context())
+
+    assert receipt.snapshot.finalized is True
+    assert receipt.snapshot.open_turn_id is None
+    assert receipt.snapshot.settled_turn_ids == ()
+    assert receipt.snapshot.abandoned_turn_ids == ("turn-1",)
+    terminal_rows = [
+        row for row in store.ledger.rows() if row["kind"] == "turn_terminal"
+    ]
+    assert len(terminal_rows) == 1
+    assert terminal_rows[0]["reason"] == "host_session_finalized"
+    assert terminal_rows[0]["outcome"] == "abandoned"
+    assert [row["hook"] for row in store.ledger.rows() if row["kind"] == "hook"] == [
+        "on_session_start",
+        "pre_llm_call",
+        "on_session_finalize",
+    ]
+
+
+def test_host_finalize_completed_turn_only_records_finalize(tmp_path) -> None:
+    store = open_turn_store(tmp_path)
+    store.record_hook(
+        context(
+            "post",
+            source_kind="assistant_response",
+            turn_id="turn-1",
+            fresh=False,
+            supported_hooks=FINALIZE_HOOKS,
+        ),
+        "post_llm_call",
+        settled=True,
+    )
+
+    receipt = store.record_host_finalize(finalize_context())
+
+    assert receipt.snapshot.finalized is True
+    assert receipt.snapshot.settled_turn_ids == ("turn-1",)
+    assert receipt.snapshot.abandoned_turn_ids == ()
+    assert [row for row in store.ledger.rows() if row["kind"] == "turn_terminal"] == []
+
+
+def test_host_finalize_is_idempotent_and_late_post_cannot_replace_abandoned_turn(
+    tmp_path,
+) -> None:
+    store = open_turn_store(tmp_path)
+    first = store.record_host_finalize(finalize_context())
+    rows_after_first = store.ledger.rows()
+    second = store.record_host_finalize(
+        finalize_context(observed_at=NOW + timedelta(minutes=1))
+    )
+
+    assert first.deduplicated is False
+    assert second.deduplicated is True
+    assert store.ledger.rows() == rows_after_first
+    with pytest.raises(SessionLifecycleError, match="already finalized"):
+        store.record_hook(
+            context(
+                "post",
+                source_kind="assistant_response",
+                turn_id="turn-1",
+                fresh=False,
+                supported_hooks=FINALIZE_HOOKS,
+            ),
+            "post_llm_call",
+            settled=True,
+        )
+
+
+def test_host_finalize_finalize_append_failure_is_completed_on_retry(
+    tmp_path, monkeypatch
+) -> None:
+    store = open_turn_store(tmp_path)
+    original_append = store.ledger.append
+    failed = {"value": True}
+
+    def fail_finalize(row):
+        if (
+            failed["value"]
+            and row["kind"] == "hook"
+            and row["hook"] == "on_session_finalize"
+        ):
+            failed["value"] = False
+            raise OSError("host finalize append fixture")
+        return original_append(row)
+
+    monkeypatch.setattr(store.ledger, "append", fail_finalize)
+    with pytest.raises(OSError, match="host finalize append fixture"):
+        store.record_host_finalize(finalize_context())
+    assert [row["kind"] for row in store.ledger.rows()] == [
+        "hook",
+        "hook",
+        "turn_terminal",
+    ]
+    assert store.snapshot("lifecycle-1").finalized is False
+
+    monkeypatch.setattr(store.ledger, "append", original_append)
+    retry = store.record_host_finalize(
+        finalize_context(observed_at=NOW + timedelta(minutes=1))
+    )
+    assert retry.snapshot.finalized is True
+    assert retry.snapshot.abandoned_turn_ids == ("turn-1",)
+    assert [row["kind"] for row in store.ledger.rows()] == [
+        "hook",
+        "hook",
+        "turn_terminal",
+        "hook",
+    ]
 
 
 def test_successor_pre_abandons_missing_post_without_settling(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- treat Hermes `session_expired` and `new_session` as permanent session boundaries
- keep Hermes `shutdown` resumable by leaving orphan repair to the existing successor `pre_llm_call` path
- atomically abandon an open turn before recording permanent session finalization
- treat `record_host_finalize` as an optional injected-owner capability while preserving the older strict `record_hook` fallback
- keep bare, missing, and unknown finalize reasons fail closed

## Verification

- 73 focused session and wiring tests
- 738 full tests
- compileall and Ruff check/format
- Hermes v0.20.5 loader contract (10 tools / 5 hooks)
- clean install lifecycle and clean wheel entry-point discovery
- wheel/sdist build and privacy scan

Closes #12