### PR TITLE
fix(session): normalize Hermes turn terminals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,19 @@ jobs:
       - run: pytest
       - run: python -m pip wheel --disable-pip-version-check --no-deps --wheel-dir "$RUNNER_TEMP/wheels" .
 
-  hermes-pinned:
+  hermes-required:
+    name: ${{ matrix.lane }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: hermes-min
+            commit: fcbd1076a93841fa88855acce810e342a5b78101
+          - lane: hermes-current
+            commit: 29112bef099274229cadff79cdff7bf7b99c4b77
     runs-on: ubuntu-latest
     env:
-      HERMES_PINNED_COMMIT: 987064caa4f8845f605ac7346fed5b72fddfb21c
+      HERMES_REQUIRED_COMMIT: ${{ matrix.commit }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -56,16 +65,16 @@ jobs:
       - run: |
           git init "$RUNNER_TEMP/hermes-agent"
           git -C "$RUNNER_TEMP/hermes-agent" remote add origin https://github.com/NousResearch/hermes-agent.git
-          git -C "$RUNNER_TEMP/hermes-agent" fetch --depth 1 origin "$HERMES_PINNED_COMMIT"
+          git -C "$RUNNER_TEMP/hermes-agent" fetch --depth 1 origin "$HERMES_REQUIRED_COMMIT"
           git -C "$RUNNER_TEMP/hermes-agent" checkout --detach FETCH_HEAD
-      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_PINNED_COMMIT" MOONBITE_TEST_HOME="$RUNNER_TEMP/hermes-home" ./scripts/test-hermes-contract.sh
-      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_PINNED_COMMIT" MOONBITE_TEST_HOME="$RUNNER_TEMP/clean-install-home" ./scripts/test-clean-install.sh
-      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_PINNED_COMMIT" ./scripts/test-clean-wheel.sh
+      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_REQUIRED_COMMIT" MOONBITE_TEST_HOME="$RUNNER_TEMP/hermes-home" ./scripts/test-hermes-contract.sh
+      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_REQUIRED_COMMIT" MOONBITE_TEST_HOME="$RUNNER_TEMP/clean-install-home" ./scripts/test-clean-install.sh
+      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_REQUIRED_COMMIT" ./scripts/test-clean-wheel.sh
 
-  hermes-pinned-macos:
+  hermes-current-macos:
     runs-on: macos-latest
     env:
-      HERMES_PINNED_COMMIT: 987064caa4f8845f605ac7346fed5b72fddfb21c
+      HERMES_REQUIRED_COMMIT: 29112bef099274229cadff79cdff7bf7b99c4b77
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -75,10 +84,10 @@ jobs:
       - run: |
           git init "$RUNNER_TEMP/hermes-agent"
           git -C "$RUNNER_TEMP/hermes-agent" remote add origin https://github.com/NousResearch/hermes-agent.git
-          git -C "$RUNNER_TEMP/hermes-agent" fetch --depth 1 origin "$HERMES_PINNED_COMMIT"
+          git -C "$RUNNER_TEMP/hermes-agent" fetch --depth 1 origin "$HERMES_REQUIRED_COMMIT"
           git -C "$RUNNER_TEMP/hermes-agent" checkout --detach FETCH_HEAD
-      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_PINNED_COMMIT" MOONBITE_TEST_HOME="$RUNNER_TEMP/clean-install-home" ./scripts/test-clean-install.sh
-      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_PINNED_COMMIT" ./scripts/test-clean-wheel.sh
+      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_REQUIRED_COMMIT" MOONBITE_TEST_HOME="$RUNNER_TEMP/clean-install-home" ./scripts/test-clean-install.sh
+      - run: HERMES_REPO="$RUNNER_TEMP/hermes-agent" HERMES_EXPECTED_COMMIT="$HERMES_REQUIRED_COMMIT" ./scripts/test-clean-wheel.sh
 
   hermes-latest-drift:
     if: github.event_name == 'schedule'

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 .idea/
 .vscode/
 .hermes-test/
+.hermes-test-*/
 .moonbite/
 moonbite-state/
 config/local.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Session recovery:** `hermes moonbite session status` lists exact open turns, and `session repair` appends an idempotent `abandoned` terminal for the specified current turn without fabricating a successful model response.
+- **HermesHostAdapter:** the public integration boundary now consumes Hermes `on_session_end` and normalizes successful, failed, interrupted, incomplete, session-rotation, and shutdown exits into canonical lifecycle evidence. The pinned Hermes 0.20.5 commit and official v0.21.0 release share the same tested contract.
+- **Subagent terminal fallback:** the seventh manifest hook, `subagent_stop`, uses only child session identity and bounded status to close a non-success one-shot child turn in the existing canonical terminal ledger; completed children remain owned by their own post/end evidence.
 
 ### Fixed
 
-- **Orphaned turns:** a new `pre_llm_call` safely supersedes an older turn whose `post_llm_call` was omitted, preserving append-only audit history while preventing the Conversation Gate from remaining permanently active.
+- **Orphaned turns:** `on_session_end` now closes a turn whose success-only `post_llm_call` was omitted; a new `pre_llm_call` remains the crash-recovery fallback, preventing the Conversation Gate from remaining permanently active without a TTL.
+- **Compression lifecycle correlation:** if Hermes rotates `session_id` during compression, Moonbite uses the stable `turn_id` and durable lifecycle ledger to attach post/end callbacks to the original turn; ambiguous evidence fails closed.
 
 ### Compatibility
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -26,7 +26,7 @@ The 7 manifest hooks are registered in strict `HOOK_ORDER`:
 2. `on_session_start`: Fires when a session initializes; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires immediately before model invocation; records lifecycle step and optionally attaches fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
 4. `post_llm_call`: Fires only for a non-empty, non-interrupted final response; records a completed post-model turn.
-5. `on_session_end`: Fires for every completed `run_conversation` path and maps success, failure, interruption, or incomplete exit into canonical terminal evidence without storing free-text exit details. `settled_turn_ids` independently records turns with a successful post callback.
+5. `on_session_end`: With a real `turn_id`, maps success, failure, interruption, or incomplete exit into canonical turn-terminal evidence without storing free-text exit details. Hermes CLI/TUI may instead emit an identifier-poor interrupted shutdown fallback; Moonbite correlates it to the exact durable lifecycle and closes that lifecycle's real open turn as `host_shutdown`, without inventing an ID. `settled_turn_ids` independently records turns with a successful post callback.
 6. `on_session_finalize`: Fires when a session finishes; records normalized session rotation, expiry, or shutdown evidence.
 7. `subagent_stop`: Uses only `child_session_id` and `child_status`; a non-success stop closes that child's unique open turn without reading its summary, goal, or tool history. A completed child is a no-op because its own post/end callbacks carry success.
 
@@ -35,20 +35,25 @@ The outer manifest (`plugin.yaml`) retains `manifest_version: 1` and `kind: stan
 ### Turn liveness contract
 
 Moonbite does not require `post_llm_call` to fire for every `pre_llm_call`.
-HermesHostAdapter consumes the unconditional `on_session_end` callback and the
-non-success `subagent_stop` fallback. Both converge on the same canonical
-terminal row under the same mutation lock; neither manufactures a successful
-post. A later pre-model hook remains a crash-recovery fallback. Operators can inspect open turns with
+HermesHostAdapter consumes turn-scoped `on_session_end`, identifier-poor
+interrupted shutdown fallback, and non-success `subagent_stop` evidence. All
+converge on the same canonical terminal row under the same mutation lock;
+none manufactures a successful post or a fake turn ID. The shutdown fallback
+does not finalize the lifecycle: the later `on_session_finalize` callback owns
+that session boundary. A later pre-model hook remains a crash-recovery
+fallback. Operators can inspect open turns with
 `hermes moonbite session status` and use exact-ID `session repair` only when no
 host terminal was delivered. Every path preserves the append-only ledger and
 never manufactures a completed response.
 
 Legacy Hermes compression can rotate `session_id` after `pre_llm_call` while
-keeping `turn_id` and `task_id` stable. For `post_llm_call` and
+keeping `turn_id` and `task_id` stable. For `post_llm_call` and turn-scoped
 `on_session_end`, HermesHostAdapter therefore correlates that stable `turn_id`
 against Moonbite's durable lifecycle ledger and writes the callback to the
-original lifecycle. Missing evidence remains neutral; ambiguous matches fail
-closed. This uses no recency timer or process-local correlation cache.
+original lifecycle. An identifier-poor shutdown fallback is instead correlated
+by its exact `session_id`; an unmatched session cannot close another lifecycle.
+Missing evidence remains neutral; ambiguous matches fail closed. This uses no
+recency timer or process-local correlation cache.
 
 The next pre-model callback may use the rotated session ID without a matching
 `on_session_start`. HermesHostAdapter then starts a new canonical lifecycle at

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -26,7 +26,7 @@ The 7 manifest hooks are registered in strict `HOOK_ORDER`:
 2. `on_session_start`: Fires when a session initializes; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires immediately before model invocation; records lifecycle step and optionally attaches fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
 4. `post_llm_call`: Fires only for a non-empty, non-interrupted final response; records a completed post-model turn.
-5. `on_session_end`: Fires for every completed `run_conversation` path and maps success, failure, interruption, or incomplete exit into canonical terminal evidence without storing free-text exit details.
+5. `on_session_end`: Fires for every completed `run_conversation` path and maps success, failure, interruption, or incomplete exit into canonical terminal evidence without storing free-text exit details. `settled_turn_ids` independently records turns with a successful post callback.
 6. `on_session_finalize`: Fires when a session finishes; records normalized session rotation, expiry, or shutdown evidence.
 7. `subagent_stop`: Uses only `child_session_id` and `child_status`; a non-success stop closes that child's unique open turn without reading its summary, goal, or tool history. A completed child is a no-op because its own post/end callbacks carry success.
 
@@ -57,6 +57,9 @@ attaches to an existing five- or six-hook Moonbite lifecycle, the adapter
 preserves its recorded capabilities and writes only the canonical terminal row
 for a newly available host terminal. This releases liveness without rewriting
 old rows or claiming that the old lifecycle registered a newer hook.
+The same lifecycle-level correlation applies to `on_session_finalize`, so an
+upgrade can finalize an existing four- or five-hook lifecycle while preserving
+its recorded capability set.
 
 Hermes v0.21.0 bounds ordinary plugin hook callbacks with a 30-second host
 timeout, while `subagent_stop` preserves caller-thread serialization. Moonbite's
@@ -74,6 +77,15 @@ an older binary at upgraded state.
 Heartbeat cadence writes upgrade valid legacy state to schema v4. Deployments
 must snapshot cadence state before upgrading and must not point an older
 Moonbite binary at a state directory after a v4 cadence write.
+
+### Injected runtime components
+
+The current host-injected ownership contract is
+`moon.runtime_components.v3`. It requires the canonical session terminal ports
+(`record_host_turn_end`, `record_host_child_stop`, `record_host_shutdown`, and
+`record_host_finalize`) in addition to the existing component owners. The v2
+bundle contract is rejected rather than treated as a partial compatibility
+match; session ledgers remain append-only and are not rewritten.
 
 ---
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -11,32 +11,58 @@ or undocumented implementation fields.
 | macOS | Supported | Uses the same POSIX code path; covered by the CI matrix, which must be green for release. |
 | Python | `>=3.11,<3.15` | Supports Python 3.11, 3.12, 3.13, 3.14 (pinned Hermes checkout supports 3.11–3.13). |
 | Native Windows | Unsupported | POSIX `fcntl` file locks are required for process synchronization. |
-| Hermes Baseline | `987064caa4f8845f605ac7346fed5b72fddfb21c` | Exact recorded known-good commit; required CI validation job. |
+| Hermes v0.20.5 minimum | `v2026.8.19` / `fcbd1076a93841fa88855acce810e342a5b78101` | Required CLI/Gateway compatibility lane. |
+| Hermes v0.21.0 current | `v2026.8.31` / `29112bef099274229cadff79cdff7bf7b99c4b77` | Required CLI/Gateway compatibility lane; Desktop is out of scope. |
 | Current Upstream Hermes | Dynamic | Resolved and printed by scheduled/manual drift CI. See the latest workflow log for the tested SHA. |
 
 ---
 
 ## 1. Verified Surface & Lifecycle Hooks
 
-Moonbite registers exactly 10 tools, 16 CLI commands, 1 slash command (`/moon`), and 5 manifest hooks.
+Moonbite registers exactly 10 tools, 16 CLI commands, 1 slash command (`/moon`), and 7 manifest hooks.
 
-The 5 manifest hooks are registered in strict `HOOK_ORDER`:
+The 7 manifest hooks are registered in strict `HOOK_ORDER`:
 1. `pre_gateway_dispatch`: Fires before message authorization, providing a pre-auth host context seam. Without an explicit typed host resolver, Moonbite treats this as a no-op and never reads or records unauthorized message content.
 2. `on_session_start`: Fires when a session initializes; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires immediately before model invocation; records lifecycle step and optionally attaches fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
 4. `post_llm_call`: Fires only for a non-empty, non-interrupted final response; records a completed post-model turn.
-5. `on_session_finalize`: Fires when a session finishes; records normalized session finalization.
+5. `on_session_end`: Fires for every completed `run_conversation` path and maps success, failure, interruption, or incomplete exit into canonical terminal evidence without storing free-text exit details.
+6. `on_session_finalize`: Fires when a session finishes; records normalized session rotation, expiry, or shutdown evidence.
+7. `subagent_stop`: Uses only `child_session_id` and `child_status`; a non-success stop closes that child's unique open turn without reading its summary, goal, or tool history. A completed child is a no-op because its own post/end callbacks carry success.
 
 The outer manifest (`plugin.yaml`) retains `manifest_version: 1` and `kind: standalone` because the pinned Hermes installer accepts only v1 manifests.
 
 ### Turn liveness contract
 
 Moonbite does not require `post_llm_call` to fire for every `pre_llm_call`.
-A later pre-model hook records the previous open turn as `abandoned` under the
-same mutation lock before opening its successor. Operators can inspect open
-turns with `hermes moonbite session status` and append the same non-success
-terminal with an exact-ID `session repair` command. Both paths preserve the
-append-only ledger and never manufacture a completed response.
+HermesHostAdapter consumes the unconditional `on_session_end` callback and the
+non-success `subagent_stop` fallback. Both converge on the same canonical
+terminal row under the same mutation lock; neither manufactures a successful
+post. A later pre-model hook remains a crash-recovery fallback. Operators can inspect open turns with
+`hermes moonbite session status` and use exact-ID `session repair` only when no
+host terminal was delivered. Every path preserves the append-only ledger and
+never manufactures a completed response.
+
+Legacy Hermes compression can rotate `session_id` after `pre_llm_call` while
+keeping `turn_id` and `task_id` stable. For `post_llm_call` and
+`on_session_end`, HermesHostAdapter therefore correlates that stable `turn_id`
+against Moonbite's durable lifecycle ledger and writes the callback to the
+original lifecycle. Missing evidence remains neutral; ambiguous matches fail
+closed. This uses no recency timer or process-local correlation cache.
+
+The next pre-model callback may use the rotated session ID without a matching
+`on_session_start`. HermesHostAdapter then starts a new canonical lifecycle at
+that real `pre_llm_call`; it does not invent a start callback. When an upgrade
+attaches to an existing five- or six-hook Moonbite lifecycle, the adapter
+preserves its recorded capabilities and writes only the canonical terminal row
+for a newly available host terminal. This releases liveness without rewriting
+old rows or claiming that the old lifecycle registered a newer hook.
+
+Hermes v0.21.0 bounds ordinary plugin hook callbacks with a 30-second host
+timeout, while `subagent_stop` preserves caller-thread serialization. Moonbite's
+lifecycle callbacks only normalize bounded identifiers and perform local
+append-only state transitions; model calls and delivery remain outside those
+callbacks.
 
 `settled_turn_ids` continues to contain completed turns only. An abandoned
 turn no longer holds the active-chat gate forever, but remains unsettled and
@@ -57,14 +83,21 @@ Moonbite binary at a state directory after a v4 cadence write.
 - **Atomic Operations & Locks:** State persistence uses atomic JSON writes and POSIX `fcntl.flock` locks on `*.lock` files.
 - **Fail-Closed Boundary:** Hermes-specific behavior stays at `moonbite_plugin.hermes_adapter` and the plugin registration boundary. If a required capability is absent on the host, Moonbite fails closed with a structured error.
 
-Before a release candidate, manually repeat the pinned contract check on WSL2's native Linux filesystem (not `/mnt/c`):
+Before a release candidate, manually repeat the required contract check for both
+commits on WSL2's native Linux filesystem (not `/mnt/c`):
 
 ```bash
-git -C ../hermes-agent fetch --depth 1 origin 987064caa4f8845f605ac7346fed5b72fddfb21c
-git -C ../hermes-agent checkout --detach 987064caa4f8845f605ac7346fed5b72fddfb21c
-HERMES_REPO=../hermes-agent \
-HERMES_EXPECTED_COMMIT=987064caa4f8845f605ac7346fed5b72fddfb21c \
-MOONBITE_TEST_HOME=.hermes-test ./scripts/test-hermes-contract.sh
+for commit in \
+  fcbd1076a93841fa88855acce810e342a5b78101 \
+  29112bef099274229cadff79cdff7bf7b99c4b77
+do
+  git -C ../hermes-agent fetch --depth 1 origin "$commit"
+  git -C ../hermes-agent checkout --detach FETCH_HEAD
+  HERMES_REPO=../hermes-agent \
+  HERMES_EXPECTED_COMMIT="$commit" \
+  MOONBITE_TEST_HOME=".hermes-test-$commit" \
+  ./scripts/test-hermes-contract.sh
+done
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ execution, and delivery. The main agent keeps final interpretive authority.
 Moonbite does not include a scheduler, daemon, credential store, network
 browser, model router, or messaging channel. The host owns those capabilities,
 along with raw session history and search. The Hermes adapter registers exactly
-10 tools and 5 lifecycle hooks; their exact interfaces are documented in
+10 tools and 7 lifecycle hooks; their exact interfaces are documented in
 [SETUP.md](SETUP.md) and [plugin.yaml](plugin.yaml).
 
 The hooks are `pre_gateway_dispatch`, `on_session_start`, `pre_llm_call`,
-`post_llm_call`, and `on_session_finalize`.
+`post_llm_call`, `on_session_end`, `on_session_finalize`, and
+`subagent_stop`.
 
 With the default configuration:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,11 +107,12 @@ Hermes 则继续管模型、工具、调度和投递。
 
 Moonbite 不包含调度器、后台服务、凭据存储、网络浏览器、模型路由器或消息
 渠道。这些能力以及原始会话历史与搜索都由宿主负责。Hermes 宿主适配器
-（host adapter）精确注册 10 个工具与 5 个生命周期 Hooks；完整接口见
+（host adapter）精确注册 10 个工具与 7 个生命周期 Hooks；完整接口见
 [SETUP.md](SETUP.md) 与 [plugin.yaml](plugin.yaml)。
 
-五个 Hooks 分别是 `pre_gateway_dispatch`、`on_session_start`、
-`pre_llm_call`、`post_llm_call` 与 `on_session_finalize`。
+七个 Hooks 分别是 `pre_gateway_dispatch`、`on_session_start`、
+`pre_llm_call`、`post_llm_call`、`on_session_end`、`on_session_finalize` 与
+`subagent_stop`。
 
 默认配置下：
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -137,7 +137,7 @@ Moonbite registers exactly 7 lifecycle hooks in Hermes (in actual `HOOK_ORDER`):
 2. `on_session_start`: Fires when a session starts; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires before an LLM call; records the lifecycle step and may attach fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
 4. `post_llm_call`: Fires only when Hermes has a non-empty final response and the turn was not interrupted; records a completed post-model turn.
-5. `on_session_end`: Fires at every `run_conversation` exit; records canonical terminal evidence for failure, interruption, or completion. `settled_turn_ids` independently records turns with a successful post callback.
+5. `on_session_end`: With a real `turn_id`, records canonical turn-terminal evidence for failure, interruption, or completion. An identifier-poor interrupted CLI/TUI shutdown fallback is correlated to the exact durable lifecycle and closes its real open turn as `host_shutdown`; Moonbite never invents a turn ID. `settled_turn_ids` independently records turns with a successful post callback.
 6. `on_session_finalize`: Fires at a session boundary; records normalized rotation, expiry, or shutdown evidence.
 7. `subagent_stop`: For a non-success child, reads only `child_session_id` and `child_status` and closes that child's unique open turn. A completed child is a no-op.
 
@@ -145,8 +145,12 @@ Moonbite registers exactly 7 lifecycle hooks in Hermes (in actual `HOOK_ORDER`):
 
 Hermes omits `post_llm_call` for an interrupted or empty-final-response turn,
 but still emits `on_session_end`; delegated children also emit `subagent_stop`.
-Moonbite does not treat the missing post as success: HermesHostAdapter maps
-non-success host evidence to one `abandoned` terminal.
+Hermes CLI/TUI shutdown paths may omit `turn_id` from that end callback.
+Moonbite does not treat the missing post as success: HermesHostAdapter
+correlates the shutdown fallback to the exact durable lifecycle, closes its real
+open turn as `host_shutdown`, and leaves the later `on_session_finalize`
+callback to own the session boundary. An unmatched fallback cannot guess
+another lifecycle.
 A later `pre_llm_call` still repairs an older open turn when the process died
 before any terminal callback could run.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -137,7 +137,7 @@ Moonbite registers exactly 7 lifecycle hooks in Hermes (in actual `HOOK_ORDER`):
 2. `on_session_start`: Fires when a session starts; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires before an LLM call; records the lifecycle step and may attach fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
 4. `post_llm_call`: Fires only when Hermes has a non-empty final response and the turn was not interrupted; records a completed post-model turn.
-5. `on_session_end`: Fires at every `run_conversation` exit; records canonical terminal evidence for failure, interruption, or a completed turn that had no successful post callback.
+5. `on_session_end`: Fires at every `run_conversation` exit; records canonical terminal evidence for failure, interruption, or completion. `settled_turn_ids` independently records turns with a successful post callback.
 6. `on_session_finalize`: Fires at a session boundary; records normalized rotation, expiry, or shutdown evidence.
 7. `subagent_stop`: For a non-success child, reads only `child_session_id` and `child_status` and closes that child's unique open turn. A completed child is a no-op.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -20,7 +20,7 @@ as well as how to set up a local development and testing environment.
 | Operating System | Linux (including Ubuntu 24.04 and WSL2 on native Linux filesystem) or macOS. Native Windows is **unsupported** due to mandatory POSIX `fcntl` file locks. |
 | Python | `>=3.11,<3.15` (Python 3.11, 3.12, 3.13, or 3.14 for Moonbite; pinned Hermes checkout supports 3.11–3.13). |
 | Package Manager | [`uv`](https://docs.astral.sh/uv/) (recommended) or standard Python virtual environment tooling. |
-| Target Hermes Agent | Pinned official Hermes Agent commit `987064caa4f8845f605ac7346fed5b72fddfb21c`. |
+| Target Hermes Agent | Required CLI/Gateway range: `v2026.8.19` (`fcbd1076a93841fa88855acce810e342a5b78101`) through `v2026.8.31` (`29112bef099274229cadff79cdff7bf7b99c4b77`). |
 | Filesystem | On WSL2, use the native Linux filesystem (e.g. `~`), **not** Windows mounts such as `/mnt/c`. |
 
 ---
@@ -132,19 +132,23 @@ Confirm that the output reports `ok: true`, `network_probe: "not_performed"`, `w
 
 ### 2.7 Manifest hooks lifecycle
 
-Moonbite registers exactly 5 lifecycle hooks in Hermes (in actual `HOOK_ORDER`):
+Moonbite registers exactly 7 lifecycle hooks in Hermes (in actual `HOOK_ORDER`):
 1. `pre_gateway_dispatch`: Runs before message authorization; provides a pre-authorization host context seam. Without an explicit typed host resolver, it acts as a no-op and never reads or records unauthorized message content.
 2. `on_session_start`: Fires when a session starts; records normalized session-start lifecycle telemetry when resolvable context is available.
 3. `pre_llm_call`: Fires before an LLM call; records the lifecycle step and may attach fresh Panel Afterglow or enabled Memory recall as bounded, untrusted context (never as instructions).
 4. `post_llm_call`: Fires only when Hermes has a non-empty final response and the turn was not interrupted; records a completed post-model turn.
-5. `on_session_finalize`: Fires when a session finishes; records normalized session finalization.
+5. `on_session_end`: Fires at every `run_conversation` exit; records canonical terminal evidence for failure, interruption, or a completed turn that had no successful post callback.
+6. `on_session_finalize`: Fires at a session boundary; records normalized rotation, expiry, or shutdown evidence.
+7. `subagent_stop`: For a non-success child, reads only `child_session_id` and `child_status` and closes that child's unique open turn. A completed child is a no-op.
 
 ### 2.8 Recover an orphaned turn
 
-Hermes may omit `post_llm_call` for an interrupted or empty-final-response
-turn. Moonbite does not treat the missing callback as success. When the next
-`pre_llm_call` arrives for the same lifecycle, Moonbite first appends an
-`abandoned` terminal for the old turn, then opens the new turn.
+Hermes omits `post_llm_call` for an interrupted or empty-final-response turn,
+but still emits `on_session_end`; delegated children also emit `subagent_stop`.
+Moonbite does not treat the missing post as success: HermesHostAdapter maps
+non-success host evidence to one `abandoned` terminal.
+A later `pre_llm_call` still repairs an older open turn when the process died
+before any terminal callback could run.
 
 For a session that has no new traffic, inspect the exact current IDs before
 repairing it:
@@ -235,16 +239,19 @@ uv pip install -e '.[dev]'
 Never use a live Hermes profile for plugin development or test runs. Validate against an isolated checkout using the contract test script:
 
 ```bash
-# Clone the pinned Hermes repository into a sibling directory
+# Clone the Hermes repository into a sibling directory
 git clone https://github.com/NousResearch/hermes-agent.git ../hermes-agent
-git -C ../hermes-agent fetch --depth 1 origin 987064caa4f8845f605ac7346fed5b72fddfb21c
-git -C ../hermes-agent checkout --detach 987064caa4f8845f605ac7346fed5b72fddfb21c
-
-# Run contract verification with isolated test home
-HERMES_REPO=../hermes-agent \
-HERMES_EXPECTED_COMMIT=987064caa4f8845f605ac7346fed5b72fddfb21c \
-MOONBITE_TEST_HOME=.hermes-test \
-./scripts/test-hermes-contract.sh
+for commit in \
+  fcbd1076a93841fa88855acce810e342a5b78101 \
+  29112bef099274229cadff79cdff7bf7b99c4b77
+do
+  git -C ../hermes-agent fetch --depth 1 origin "$commit"
+  git -C ../hermes-agent checkout --detach FETCH_HEAD
+  HERMES_REPO=../hermes-agent \
+  HERMES_EXPECTED_COMMIT="$commit" \
+  MOONBITE_TEST_HOME=".hermes-test-$commit" \
+  ./scripts/test-hermes-contract.sh
+done
 ```
 
 ---

--- a/docs/INSTALL_FOR_AGENTS.md
+++ b/docs/INSTALL_FOR_AGENTS.md
@@ -60,7 +60,7 @@ Before modifying any configuration, agents should formulate and present a struct
 {
   "schema_version": "moonbite.setup_plan.v1",
   "source_commit": "<40-character-commit-sha>",
-  "hermes_commit": "987064caa4f8845f605ac7346fed5b72fddfb21c",
+  "hermes_commit": "<required-hermes-commit>",
   "target_profile": null,
   "preset": null,
   "owner_decisions_required": [
@@ -95,7 +95,9 @@ Before modifying any configuration, agents should formulate and present a struct
     "on_session_start",
     "pre_llm_call",
     "post_llm_call",
-    "on_session_finalize"
+    "on_session_end",
+    "on_session_finalize",
+    "subagent_stop"
   ],
   "smoke_tests": [
     "hermes plugins doctor moonbite --ci",

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -18,12 +18,14 @@ This checklist is an authoritative guide for repository owners preparing a publi
   .venv/bin/ruff format --check moonbite_plugin tests scripts/check-hermes-contract.py
   ```
 
-- [ ] **Pinned Hermes Contract Validation:**
-  Verify against official pinned Hermes commit `987064caa4f8845f605ac7346fed5b72fddfb21c`:
+- [ ] **Required Hermes Contract Matrix:**
+  Repeat the contract, clean-wheel, and clean-install checks for both official
+  commits: `fcbd1076a93841fa88855acce810e342a5b78101` (v0.20.5) and
+  `29112bef099274229cadff79cdff7bf7b99c4b77` (v0.21.0):
   ```bash
   HERMES_REPO=/path/to/hermes-agent \
-  HERMES_EXPECTED_COMMIT=987064caa4f8845f605ac7346fed5b72fddfb21c \
-  MOONBITE_TEST_HOME=.hermes-test \
+  HERMES_EXPECTED_COMMIT=<required-hermes-commit> \
+  MOONBITE_TEST_HOME=.hermes-test-<lane> \
   ./scripts/test-hermes-contract.sh
   ```
 
@@ -69,7 +71,7 @@ This checklist is an authoritative guide for repository owners preparing a publi
   Verify package contents, import origin, entry-point discovery, `register`, and opt-in loading in the repository's isolated runner:
   ```bash
   HERMES_REPO=/path/to/isolated/hermes-agent \
-  HERMES_EXPECTED_COMMIT=987064caa4f8845f605ac7346fed5b72fddfb21c \
+  HERMES_EXPECTED_COMMIT=<required-hermes-commit> \
   ./scripts/test-clean-wheel.sh
   ```
 
@@ -78,8 +80,8 @@ This checklist is an authoritative guide for repository owners preparing a publi
   enable, fresh-process surfaces, safe smoke, disable, and state retention:
   ```bash
   HERMES_REPO=/path/to/isolated/hermes-agent \
-  HERMES_EXPECTED_COMMIT=987064caa4f8845f605ac7346fed5b72fddfb21c \
-  MOONBITE_TEST_HOME=/path/to/empty/test-home \
+  HERMES_EXPECTED_COMMIT=<required-hermes-commit> \
+  MOONBITE_TEST_HOME=/path/to/empty/test-home-<lane> \
   ./scripts/test-clean-install.sh
   ```
 

--- a/moonbite_plugin/components.py
+++ b/moonbite_plugin/components.py
@@ -32,7 +32,15 @@ REQUIRED_STATE_DOMAINS = frozenset(
 RESERVED_STATE_DOMAINS = frozenset()
 MAX_OWNER_ID_BYTES = 256
 STANDALONE_OWNER_ID = "moonbite-standalone"
-SESSION_OWNER_METHODS = ("record_hook", "snapshot", "replay")
+SESSION_OWNER_METHODS = (
+    "record_hook",
+    "record_host_turn_end",
+    "record_host_child_stop",
+    "record_host_shutdown",
+    "record_host_finalize",
+    "snapshot",
+    "replay",
+)
 EFFECT_OWNER_METHODS = (
     "begin_intent",
     "mark_pending",

--- a/moonbite_plugin/components.py
+++ b/moonbite_plugin/components.py
@@ -14,7 +14,7 @@ from .panel import PanelStore
 from .runtime_core import EventBus, FileRuntimeLocks, RuntimeLocks, ensure_bounded_text
 from .session import SessionLifecycleStore
 
-RUNTIME_COMPONENTS_SCHEMA = "moon.runtime_components.v2"
+RUNTIME_COMPONENTS_SCHEMA = "moon.runtime_components.v3"
 REQUIRED_STATE_DOMAINS = frozenset(
     {
         "event",

--- a/moonbite_plugin/hermes_adapter.py
+++ b/moonbite_plugin/hermes_adapter.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, replace
 from datetime import date
 import inspect
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from .autonomy import AutonomyContext, AutonomyDecision
 from .heartbeat import (
@@ -14,6 +15,256 @@ from .heartbeat import (
     JudgeDecision,
 )
 from .memory import DiaryDraft
+from .runtime_core import ensure_bounded_text, utc_now
+from .session import SessionContext, SessionLifecycleSnapshot
+
+
+_DEFINITIVE_FINALIZE_REASONS = frozenset({"new_session", "session_expired"})
+_TURN_TERMINAL_REASONS = frozenset(
+    {
+        "host_turn_completed_without_post",
+        "host_turn_failed",
+        "host_turn_incomplete",
+        "host_turn_interrupted",
+    }
+)
+_CHILD_STOP_STATUSES = frozenset(
+    {
+        "completed",
+        "interrupted",
+        "failed",
+        "error",
+        "timeout",
+    }
+)
+
+
+class SessionHookMappingError(ValueError):
+    """Raised when public Hermes hook kwargs cannot form canonical evidence."""
+
+
+def _hook_reference(value: Any, label: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise SessionHookMappingError(f"{label} is required for session hook mapping")
+    try:
+        ensure_bounded_text(value, label, max_bytes=256)
+    except ValueError as exc:
+        raise SessionHookMappingError(str(exc)) from exc
+    return value
+
+
+def _optional_hook_reference(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _hook_reference(value, label)
+
+
+@dataclass(frozen=True, slots=True)
+class HermesTurnTerminal:
+    """Canonical terminal classification derived from one Hermes turn end."""
+
+    context: SessionContext
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.reason not in _TURN_TERMINAL_REASONS:
+            raise ValueError("unsupported Hermes turn terminal reason")
+
+
+@dataclass(frozen=True, slots=True)
+class HermesChildStop:
+    """Bounded child-stop evidence accepted from Hermes."""
+
+    child_session_id: str
+    reason: str
+
+    @property
+    def terminal_reason(self) -> str:
+        return self.reason
+
+
+class HermesHostAdapter:
+    """The sole raw Hermes lifecycle compatibility boundary for Moonbite."""
+
+    def __init__(self, *, clock: Callable[[], Any] = utc_now):
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self.clock = clock
+
+    def session_context(
+        self,
+        hook: str,
+        kwargs: Mapping[str, Any],
+        supported_hooks: frozenset[str],
+    ) -> SessionContext | None:
+        if hook == "pre_gateway_dispatch":
+            # This hook runs before authorization and has no stable session ID.
+            return None
+
+        session_id = _hook_reference(kwargs.get("session_id"), "session_id")
+        observed_at = self.clock()
+
+        if hook == "on_session_start":
+            return SessionContext(
+                session_id=session_id,
+                lifecycle_id=session_id,
+                source_id=session_id,
+                source_kind="session_start",
+                observed_at=observed_at,
+                fresh=True,
+                supported_hooks=supported_hooks,
+            )
+
+        if hook in {"pre_llm_call", "post_llm_call", "on_session_end"}:
+            turn_id = _hook_reference(kwargs.get("turn_id"), "turn_id")
+            task_id = _optional_hook_reference(kwargs.get("task_id"), "task_id")
+            return SessionContext(
+                session_id=session_id,
+                lifecycle_id=session_id,
+                source_id=task_id or turn_id,
+                turn_id=turn_id,
+                source_kind=(
+                    "assistant_response" if hook == "post_llm_call" else "system"
+                ),
+                observed_at=observed_at,
+                fresh=False,
+                supported_hooks=supported_hooks,
+            )
+
+        if hook == "on_session_finalize":
+            return SessionContext(
+                session_id=session_id,
+                lifecycle_id=session_id,
+                source_id=session_id,
+                source_kind="system",
+                observed_at=observed_at,
+                fresh=False,
+                supported_hooks=supported_hooks,
+            )
+
+        raise SessionHookMappingError(f"unsupported session hook: {hook!r}")
+
+    def turn_terminal(
+        self,
+        kwargs: Mapping[str, Any],
+        *,
+        supported_hooks: frozenset[str],
+        context: SessionContext | None = None,
+    ) -> HermesTurnTerminal:
+        if context is None:
+            context = self.session_context("on_session_end", kwargs, supported_hooks)
+        if not isinstance(context, SessionContext):
+            raise SessionHookMappingError("on_session_end requires session context")
+        for field in ("completed", "failed", "interrupted"):
+            if type(kwargs.get(field)) is not bool:
+                raise SessionHookMappingError(
+                    f"{field} is required for on_session_end mapping"
+                )
+        _hook_reference(kwargs.get("turn_exit_reason"), "turn_exit_reason")
+        if kwargs["interrupted"]:
+            reason = "host_turn_interrupted"
+        elif kwargs["failed"]:
+            reason = "host_turn_failed"
+        elif kwargs["completed"]:
+            reason = "host_turn_completed_without_post"
+        else:
+            reason = "host_turn_incomplete"
+        return HermesTurnTerminal(context=context, reason=reason)
+
+    def subagent_stop_terminal(
+        self, kwargs: Mapping[str, Any]
+    ) -> HermesChildStop | None:
+        """Normalize Hermes child-stop status without inspecting child content."""
+
+        child_session_id = _hook_reference(
+            kwargs.get("child_session_id"), "child_session_id"
+        )
+        child_status = _hook_reference(kwargs.get("child_status"), "child_status")
+        if child_status not in _CHILD_STOP_STATUSES:
+            raise SessionHookMappingError(f"unsupported child_status: {child_status!r}")
+        if child_status == "completed":
+            return None
+        reason = (
+            "host_turn_interrupted"
+            if child_status == "interrupted"
+            else "host_turn_failed"
+        )
+        return HermesChildStop(child_session_id=child_session_id, reason=reason)
+
+    @staticmethod
+    def correlate_turn(
+        context: SessionContext,
+        snapshots: tuple[SessionLifecycleSnapshot, ...],
+    ) -> SessionContext:
+        """Resolve a rotated Hermes session ID from durable turn evidence."""
+
+        if context.turn_id is None:
+            return context
+        candidates = [
+            snapshot
+            for snapshot in snapshots
+            if context.turn_id == snapshot.open_turn_id
+            or context.turn_id in snapshot.terminal_turn_ids
+            or context.turn_id in snapshot.settled_turn_ids
+            or context.turn_id in snapshot.abandoned_turn_ids
+        ]
+        if not candidates:
+            return context
+        if len(candidates) != 1:
+            raise SessionHookMappingError(
+                "turn_id matches multiple Moonbite session lifecycles"
+            )
+        snapshot = candidates[0]
+        return replace(
+            context,
+            session_id=snapshot.session_id,
+            lifecycle_id=snapshot.lifecycle_id,
+            supported_hooks=snapshot.supported_hooks,
+        )
+
+    @staticmethod
+    def pre_turn_context(
+        context: SessionContext,
+        snapshots: tuple[SessionLifecycleSnapshot, ...],
+    ) -> SessionContext:
+        """Reuse an existing lifecycle or attach after a host session rotation."""
+
+        matches = [
+            snapshot
+            for snapshot in snapshots
+            if snapshot.lifecycle_id == context.lifecycle_id
+        ]
+        if len(matches) > 1:
+            raise SessionHookMappingError(
+                "session_id matches multiple Moonbite session lifecycles"
+            )
+        if matches:
+            snapshot = matches[0]
+            return replace(
+                context,
+                session_id=snapshot.session_id,
+                lifecycle_id=snapshot.lifecycle_id,
+                supported_hooks=snapshot.supported_hooks,
+            )
+        # Hermes legacy compression can rotate session_id without firing a
+        # matching on_session_start. A pre-model hook is enough to start the
+        # new canonical lifecycle; no synthetic start callback is recorded.
+        return replace(
+            context,
+            supported_hooks=context.supported_hooks - {"on_session_start"},
+        )
+
+    @staticmethod
+    def finalize_disposition(kwargs: Mapping[str, Any]) -> str:
+        reason = kwargs.get("reason")
+        if reason is None:
+            return "ordinary"
+        reason = _hook_reference(reason, "reason")
+        if reason == "shutdown":
+            return "shutdown"
+        if reason in _DEFINITIVE_FINALIZE_REASONS:
+            return "definitive"
+        return "ordinary"
 
 
 HEARTBEAT_DECISION_SCHEMA = {

--- a/moonbite_plugin/hermes_adapter.py
+++ b/moonbite_plugin/hermes_adapter.py
@@ -22,6 +22,9 @@ from .session import SessionContext, SessionLifecycleSnapshot
 _DEFINITIVE_FINALIZE_REASONS = frozenset({"new_session", "session_expired"})
 _TURN_TERMINAL_REASONS = frozenset(
     {
+        "host_turn_completed",
+        # Keep accepting this legacy label so old lifecycle rows remain
+        # readable; new host callbacks use the neutral reason above.
         "host_turn_completed_without_post",
         "host_turn_failed",
         "host_turn_incomplete",
@@ -166,7 +169,7 @@ class HermesHostAdapter:
         elif kwargs["failed"]:
             reason = "host_turn_failed"
         elif kwargs["completed"]:
-            reason = "host_turn_completed_without_post"
+            reason = "host_turn_completed"
         else:
             reason = "host_turn_incomplete"
         return HermesTurnTerminal(context=context, reason=reason)
@@ -215,6 +218,32 @@ class HermesHostAdapter:
                 "turn_id matches multiple Moonbite session lifecycles"
             )
         snapshot = candidates[0]
+        return replace(
+            context,
+            session_id=snapshot.session_id,
+            lifecycle_id=snapshot.lifecycle_id,
+            supported_hooks=snapshot.supported_hooks,
+        )
+
+    @staticmethod
+    def correlate_lifecycle(
+        context: SessionContext,
+        snapshots: tuple[SessionLifecycleSnapshot, ...],
+    ) -> SessionContext:
+        """Reuse durable lifecycle identity and capabilities for session hooks."""
+
+        matches = [
+            snapshot
+            for snapshot in snapshots
+            if snapshot.lifecycle_id == context.lifecycle_id
+        ]
+        if not matches:
+            return context
+        if len(matches) != 1:
+            raise SessionHookMappingError(
+                "session_id matches multiple Moonbite session lifecycles"
+            )
+        snapshot = matches[0]
         return replace(
             context,
             session_id=snapshot.session_id,

--- a/moonbite_plugin/hermes_adapter.py
+++ b/moonbite_plugin/hermes_adapter.py
@@ -57,7 +57,7 @@ def _hook_reference(value: Any, label: str) -> str:
 
 
 def _optional_hook_reference(value: Any, label: str) -> str | None:
-    if value is None:
+    if value is None or (type(value) is str and not value.strip()):
         return None
     return _hook_reference(value, label)
 
@@ -146,6 +146,49 @@ class HermesHostAdapter:
             )
 
         raise SessionHookMappingError(f"unsupported session hook: {hook!r}")
+
+    def session_end_shutdown_fallback(
+        self,
+        kwargs: Mapping[str, Any],
+        *,
+        supported_hooks: frozenset[str],
+    ) -> SessionContext | None:
+        """Map Hermes' identifier-poor interrupted shutdown fallback.
+
+        CLI and TUI shutdown paths can emit ``on_session_end`` without a
+        usable turn identifier.  This context identifies only the durable
+        lifecycle; the session owner resolves and closes its real open turn.
+        """
+
+        raw_turn_id = kwargs.get("turn_id")
+        if raw_turn_id is not None:
+            if type(raw_turn_id) is not str:
+                raise SessionHookMappingError(
+                    "turn_id must be text for on_session_end mapping"
+                )
+            if raw_turn_id.strip():
+                return None
+
+        completed = kwargs.get("completed")
+        interrupted = kwargs.get("interrupted")
+        failed = kwargs.get("failed")
+        if failed is not None and type(failed) is not bool:
+            raise SessionHookMappingError(
+                "failed must be a bool for on_session_end mapping"
+            )
+        if completed is not False or interrupted is not True or failed is True:
+            return None
+
+        session_id = _hook_reference(kwargs.get("session_id"), "session_id")
+        return SessionContext(
+            session_id=session_id,
+            lifecycle_id=session_id,
+            source_id=session_id,
+            source_kind="system",
+            observed_at=self.clock(),
+            fresh=False,
+            supported_hooks=supported_hooks,
+        )
 
     def turn_terminal(
         self,

--- a/moonbite_plugin/plugin.py
+++ b/moonbite_plugin/plugin.py
@@ -882,6 +882,12 @@ def register_runtime(
     def post_llm_call(**kwargs: Any) -> None:
         runtime.record_session_hook("post_llm_call", kwargs, settled=True)
 
+    def on_session_end(**kwargs: Any) -> None:
+        runtime.record_hermes_turn_end(kwargs)
+
+    def subagent_stop(**kwargs: Any) -> None:
+        runtime.record_hermes_subagent_stop(kwargs)
+
     def on_session_finalize(**kwargs: Any) -> None:
         runtime.record_hermes_session_finalize(kwargs)
 
@@ -890,7 +896,9 @@ def register_runtime(
         "on_session_start": on_session_start,
         "pre_llm_call": pre_llm_call,
         "post_llm_call": post_llm_call,
+        "on_session_end": on_session_end,
         "on_session_finalize": on_session_finalize,
+        "subagent_stop": subagent_stop,
     }
     for hook_name in HOOK_ORDER:
         if hook_name in plan.hook_names:

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -340,10 +340,15 @@ class MoonbiteRuntime:
             "pre_llm_call",
             "post_llm_call",
             "on_session_end",
+            "on_session_finalize",
         }:
             snapshots = self.session.replay()
             if hook == "pre_llm_call":
                 context = self.hermes_host_adapter.pre_turn_context(context, snapshots)
+            elif hook == "on_session_finalize":
+                context = self.hermes_host_adapter.correlate_lifecycle(
+                    context, snapshots
+                )
             else:
                 context = self.hermes_host_adapter.correlate_turn(context, snapshots)
         return context

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -889,7 +889,7 @@ class MoonbiteRuntime:
             if type(value) is not bool:
                 return value
             provided = provided or value
-        return provided or self._conversation_active_chat()
+        return provided or self._conversation_private_chat_active()
 
     def run_heartbeat(
         self, kind: str, *, context: Mapping[str, Any] | None = None
@@ -969,8 +969,8 @@ class MoonbiteRuntime:
         self._project_autonomy_afterglow(result)
         return result
 
-    def _conversation_active_chat(self) -> bool:
-        """Return the durable conversation gate, failing closed on uncertainty."""
+    def _conversation_chat_active(self, *, require_private: bool) -> bool:
+        """Read the durable chat gate, optionally requiring private input."""
 
         bridge = self.conversation_bridge
         if bridge is None:
@@ -990,14 +990,43 @@ class MoonbiteRuntime:
             for snapshot in snapshots:
                 if isinstance(snapshot, Mapping):
                     value = snapshot["active_chat"]
+                    last_private_at = snapshot.get("last_private_at")
                 else:
                     value = getattr(snapshot, "active_chat")
+                    last_private_at = getattr(snapshot, "last_private_at", None)
                 if type(value) is not bool:
                     raise TypeError("conversation bridge active_chat is invalid")
+                if require_private:
+                    if isinstance(snapshot, Mapping):
+                        has_private_field = "last_private_at" in snapshot
+                    else:
+                        has_private_field = hasattr(snapshot, "last_private_at")
+                    if not has_private_field:
+                        raise TypeError(
+                            "conversation bridge last_private_at is unavailable"
+                        )
+                    if last_private_at is not None and not isinstance(
+                        last_private_at, datetime
+                    ):
+                        raise TypeError(
+                            "conversation bridge last_private_at is invalid"
+                        )
+                    if value and last_private_at is None:
+                        continue
                 active_values.append(value)
             return any(active_values)
         except Exception:
             return True
+
+    def _conversation_active_chat(self) -> bool:
+        """Return any durable active turn, failing closed on uncertainty."""
+
+        return self._conversation_chat_active(require_private=False)
+
+    def _conversation_private_chat_active(self) -> bool:
+        """Return only active conversation state backed by private input."""
+
+        return self._conversation_chat_active(require_private=True)
 
     @staticmethod
     def _afterglow_summary(result: ActivityResult) -> str:

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -415,6 +415,48 @@ class MoonbiteRuntime:
         hook = "on_session_end"
         payload = {} if kwargs is None else kwargs
         try:
+            fallback_context = self.hermes_host_adapter.session_end_shutdown_fallback(
+                payload,
+                supported_hooks=DEFAULT_SESSION_HOOKS,
+            )
+            if fallback_context is not None:
+                if self.session_context_resolver is not None:
+                    fallback_context = self.session_context_resolver(
+                        hook,
+                        payload,
+                        SUPPORTED_SESSION_HOOKS,
+                    )
+                    if fallback_context is None:
+                        raise SessionHookMappingError(
+                            "session_context_resolver did not map the on_session_end shutdown fallback"
+                        )
+                    if not isinstance(fallback_context, SessionContext):
+                        raise SessionHookMappingError(
+                            "session_context_resolver must return SessionContext or None"
+                        )
+                snapshots = self.session.replay()
+                fallback_context = self.hermes_host_adapter.correlate_lifecycle(
+                    fallback_context,
+                    snapshots,
+                )
+                if not any(
+                    snapshot.lifecycle_id == fallback_context.lifecycle_id
+                    for snapshot in snapshots
+                ):
+                    raise SessionHookMappingError(
+                        "on_session_end shutdown fallback did not match a durable lifecycle"
+                    )
+                record_host_shutdown = getattr(
+                    self.session, "record_host_shutdown", None
+                )
+                if not callable(record_host_shutdown):
+                    raise RuntimeComponentsError(
+                        "session owner is missing record_host_shutdown"
+                    )
+                receipt = record_host_shutdown(fallback_context)
+                self._last_session_hook_error = None
+                return receipt
+
             context = self._resolve_session_context(hook, payload)
             if context is None:
                 return None

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -874,13 +874,30 @@ class MoonbiteRuntime:
     ) -> dict[str, Any]:
         return self.bus.emit(kind, source=source, payload=payload).to_dict()
 
+    def _effective_active_chat(
+        self,
+        values: Mapping[str, Any],
+        *keys: str,
+    ) -> Any:
+        """Merge a host gate with the durable bridge without lowering either."""
+
+        provided = False
+        for key in keys:
+            if key not in values:
+                continue
+            value = values[key]
+            if type(value) is not bool:
+                return value
+            provided = provided or value
+        return provided or self._conversation_active_chat()
+
     def run_heartbeat(
         self, kind: str, *, context: Mapping[str, Any] | None = None
     ) -> HeartbeatResult:
         if not self.config["modules"]["heartbeat"]:
             raise RuntimeError("heartbeat module is disabled")
         effective_context = {} if context is None else dict(context)
-        active_chat = self._conversation_active_chat()
+        active_chat = self._effective_active_chat(effective_context, "active_chat")
         effective_context["active_chat"] = active_chat
         return self.heartbeat.run(
             HeartbeatCandidate(kind, effective_context), active_chat=active_chat
@@ -939,7 +956,11 @@ class MoonbiteRuntime:
         if not self.config["modules"]["autonomy"]:
             raise RuntimeError("autonomy module is disabled")
         effective_facts = {} if facts is None else dict(facts)
-        active_chat = self._conversation_active_chat()
+        active_chat = self._effective_active_chat(
+            effective_facts,
+            "active_chat",
+            "chat_active",
+        )
         effective_facts["active_chat"] = active_chat
         effective_facts["chat_active"] = active_chat
         result = self.autonomy.run_once(

--- a/moonbite_plugin/service.py
+++ b/moonbite_plugin/service.py
@@ -35,6 +35,7 @@ from .heartbeat import (
     SilentJudge,
     WakeSink,
 )
+from .hermes_adapter import HermesHostAdapter, SessionHookMappingError
 from .memory import (
     DiaryWriter,
     ExternalRetriever,
@@ -53,8 +54,13 @@ from .memory_orchestration import (
 )
 from .observer import HealthSnapshot, ObservationFact, Observer, ScheduleProof
 from .platforms import PlatformInfo, detect_platform, state_root
-from .runtime_core import StateError, ensure_bounded_text, new_id, parse_time, utc_now
-from .session import HOOK_ORDER, SessionContext, SessionHookReceipt
+from .runtime_core import StateError, new_id, parse_time, utc_now
+from .session import (
+    HOOK_ORDER,
+    SessionContext,
+    SessionHookReceipt,
+    SessionTurnTerminalReceipt,
+)
 from .scenarios import ConfigResolution, resolve_config
 
 logger = logging.getLogger(__name__)
@@ -65,30 +71,9 @@ SUPPORTED_SESSION_HOOKS = frozenset(SESSION_HOOK_ORDER)
 DEFAULT_SESSION_HOOKS = frozenset(
     hook for hook in SUPPORTED_SESSION_HOOKS if hook != "pre_gateway_dispatch"
 )
-_DEFINITIVE_HERMES_FINALIZE_REASONS = frozenset({"new_session", "session_expired"})
 SessionContextResolver = Callable[
     [str, Mapping[str, Any], frozenset[str]], SessionContext | None
 ]
-
-
-class SessionHookMappingError(ValueError):
-    """Raised when public Hermes kwargs cannot form a safe session context."""
-
-
-def _hook_reference(value: Any, label: str) -> str:
-    if type(value) is not str or not value.strip():
-        raise SessionHookMappingError(f"{label} is required for session hook mapping")
-    try:
-        ensure_bounded_text(value, label, max_bytes=256)
-    except ValueError as exc:
-        raise SessionHookMappingError(str(exc)) from exc
-    return value
-
-
-def _optional_hook_reference(value: Any, label: str) -> str | None:
-    if value is None:
-        return None
-    return _hook_reference(value, label)
 
 
 _MISSING = object()
@@ -258,6 +243,7 @@ class MoonbiteRuntime:
             raise RuntimeComponentsError(
                 "session_context_resolver must be callable or None"
             )
+        self.hermes_host_adapter = HermesHostAdapter()
         self.session_context_resolver = session_context_resolver
         self._last_session_hook_error: dict[str, str] | None = None
         self.providers = ProviderRegistry()
@@ -335,61 +321,46 @@ class MoonbiteRuntime:
             "error": type(error).__name__,
         }
 
-    @staticmethod
-    def _default_session_context(
-        hook: str, kwargs: Mapping[str, Any]
+    def _resolve_session_context(
+        self, hook: str, payload: Mapping[str, Any]
     ) -> SessionContext | None:
-        """Map stable public Hermes IDs without inspecting message bodies."""
-
-        if hook == "pre_gateway_dispatch":
-            # The public gateway callback has no authorized session ID and runs
-            # before auth.  A caller-owned resolver may opt in explicitly.
-            return None
-
-        session_id = _hook_reference(kwargs.get("session_id"), "session_id")
-        lifecycle_id = session_id
-        observed_at = utc_now()
-
-        if hook == "on_session_start":
-            return SessionContext(
-                session_id=session_id,
-                lifecycle_id=lifecycle_id,
-                source_id=session_id,
-                source_kind="session_start",
-                observed_at=observed_at,
-                fresh=True,
-                supported_hooks=DEFAULT_SESSION_HOOKS,
+        if self.session_context_resolver is None:
+            context = self.hermes_host_adapter.session_context(
+                hook, payload, DEFAULT_SESSION_HOOKS
             )
-
-        if hook in {"pre_llm_call", "post_llm_call"}:
-            turn_id = _hook_reference(kwargs.get("turn_id"), "turn_id")
-            task_id = _optional_hook_reference(kwargs.get("task_id"), "task_id")
-            source_id = task_id or turn_id
-            return SessionContext(
-                session_id=session_id,
-                lifecycle_id=lifecycle_id,
-                source_id=source_id,
-                turn_id=turn_id,
-                source_kind=(
-                    "assistant_response" if hook == "post_llm_call" else "system"
-                ),
-                observed_at=observed_at,
-                fresh=False,
-                supported_hooks=DEFAULT_SESSION_HOOKS,
+        else:
+            context = self.session_context_resolver(
+                hook, payload, SUPPORTED_SESSION_HOOKS
             )
-
-        if hook == "on_session_finalize":
-            return SessionContext(
-                session_id=session_id,
-                lifecycle_id=lifecycle_id,
-                source_id=session_id,
-                source_kind="system",
-                observed_at=observed_at,
-                fresh=False,
-                supported_hooks=DEFAULT_SESSION_HOOKS,
+        if context is not None and not isinstance(context, SessionContext):
+            raise SessionHookMappingError(
+                "session_context_resolver must return SessionContext or None"
             )
+        if context is not None and hook in {
+            "pre_llm_call",
+            "post_llm_call",
+            "on_session_end",
+        }:
+            snapshots = self.session.replay()
+            if hook == "pre_llm_call":
+                context = self.hermes_host_adapter.pre_turn_context(context, snapshots)
+            else:
+                context = self.hermes_host_adapter.correlate_turn(context, snapshots)
+        return context
 
-        raise SessionHookMappingError(f"unsupported session hook: {hook!r}")
+    def _project_session_receipt(self, hook: str, receipt: SessionHookReceipt):
+        try:
+            if self.conversation_bridge is not None:
+                self.conversation_bridge.observe(receipt)
+            if receipt.context.counts_as_private_contact:
+                self.cadence.record_private_contact(receipt)
+        except Exception as exc:
+            # The session owner already accepted this receipt. Projection
+            # retries are safe because both consumers are idempotent.
+            self._remember_session_hook_error(hook, exc)
+            raise
+        self._last_session_hook_error = None
+        return receipt
 
     def record_session_hook(
         self,
@@ -397,7 +368,6 @@ class MoonbiteRuntime:
         kwargs: Mapping[str, Any] | None = None,
         *,
         settled: bool = False,
-        _record_host_finalize: bool = False,
     ):
         """Map one public hook and append it to the injected session owner.
 
@@ -409,82 +379,150 @@ class MoonbiteRuntime:
 
         payload = {} if kwargs is None else kwargs
         try:
-            if self.session_context_resolver is None and hook == "on_session_finalize":
-                raw_session_id = payload.get("session_id")
-                if raw_session_id is None or (
-                    type(raw_session_id) is str and not raw_session_id.strip()
-                ):
-                    return None
-                session_id = _hook_reference(raw_session_id, "session_id")
-                if self.session.snapshot(session_id) is None:
-                    # Hermes can finalize a session that never reached its
-                    # first turn (for example /new during setup).  There is
-                    # no lifecycle to close and therefore nothing to record.
-                    return None
-            if self.session_context_resolver is None:
-                context = self._default_session_context(hook, payload)
-            else:
-                context = self.session_context_resolver(
-                    hook, payload, SUPPORTED_SESSION_HOOKS
-                )
+            context = self._resolve_session_context(hook, payload)
             if context is None:
                 return None
-            if not isinstance(context, SessionContext):
-                raise SessionHookMappingError(
-                    "session_context_resolver must return SessionContext or None"
-                )
             event = payload.get("event")
             if hook == "pre_gateway_dispatch" and getattr(event, "internal", False):
                 # Internal/system events are never contact, even when a
                 # resolver is present.
                 return None
-            if _record_host_finalize:
-                record_host_finalize = getattr(
-                    self.session, "record_host_finalize", None
-                )
-                if callable(record_host_finalize):
-                    receipt = record_host_finalize(context)
-                else:
-                    receipt = self.session.record_hook(context, hook, settled=settled)
-            else:
-                receipt = self.session.record_hook(context, hook, settled=settled)
+            if (
+                hook == "on_session_finalize"
+                and self.session.snapshot(context.lifecycle_id) is None
+            ):
+                # Hermes can finalize a session that never reached a first turn.
+                return None
+            receipt = self.session.record_hook(context, hook, settled=settled)
         except SessionHookMappingError as exc:
             self._remember_session_hook_error(hook, exc)
             return None
         except Exception as exc:
             self._remember_session_hook_error(hook, exc)
             raise
+        return self._project_session_receipt(hook, receipt)
+
+    def record_hermes_turn_end(
+        self, kwargs: Mapping[str, Any] | None = None
+    ) -> SessionHookReceipt | SessionTurnTerminalReceipt | None:
+        """Normalize Hermes' unconditional turn end into canonical evidence."""
+
+        hook = "on_session_end"
+        payload = {} if kwargs is None else kwargs
         try:
-            if self.conversation_bridge is not None:
-                self.conversation_bridge.observe(receipt)
-            if receipt.context.counts_as_private_contact:
-                self.cadence.record_private_contact(receipt)
+            context = self._resolve_session_context(hook, payload)
+            if context is None:
+                return None
+            terminal = self.hermes_host_adapter.turn_terminal(
+                payload,
+                supported_hooks=context.supported_hooks,
+                context=context,
+            )
+            record_host_turn_end = getattr(self.session, "record_host_turn_end", None)
+            if not callable(record_host_turn_end):
+                raise RuntimeComponentsError(
+                    "session owner is missing record_host_turn_end"
+                )
+            receipt = record_host_turn_end(terminal.context, terminal.reason)
+            if receipt is None:
+                return None
+        except SessionHookMappingError as exc:
+            self._remember_session_hook_error(hook, exc)
+            return None
         except Exception as exc:
-            # The session owner has already durably accepted this receipt. A
-            # projection failure must remain visible so the host can retry;
-            # ConversationBridge.observe is idempotent on that retry.
             self._remember_session_hook_error(hook, exc)
             raise
+        if isinstance(receipt, SessionHookReceipt):
+            return self._project_session_receipt(hook, receipt)
+        if not isinstance(receipt, SessionTurnTerminalReceipt):
+            raise RuntimeComponentsError(
+                "session owner returned an invalid host turn terminal receipt"
+            )
         self._last_session_hook_error = None
         return receipt
 
-    def record_hermes_session_finalize(
+    def record_hermes_subagent_stop(
         self, kwargs: Mapping[str, Any] | None = None
-    ) -> SessionHookReceipt | None:
-        """Route only definitive Hermes finalization reasons to host close."""
+    ) -> SessionHookReceipt | SessionTurnTerminalReceipt | None:
+        """Normalize Hermes child-stop fallback into canonical evidence."""
 
+        hook = "subagent_stop"
         payload = {} if kwargs is None else kwargs
-        reason = payload.get("reason")
-        if type(reason) is str and reason == "shutdown":
+        try:
+            child_stop = self.hermes_host_adapter.subagent_stop_terminal(payload)
+            if child_stop is None:
+                self._last_session_hook_error = None
+                return None
+            record_host_child_stop = getattr(
+                self.session, "record_host_child_stop", None
+            )
+            if not callable(record_host_child_stop):
+                raise RuntimeComponentsError(
+                    "session owner is missing record_host_child_stop"
+                )
+            receipt = record_host_child_stop(
+                child_stop.child_session_id,
+                child_stop.reason,
+            )
+        except SessionHookMappingError as exc:
+            self._remember_session_hook_error(hook, exc)
             return None
-        definitive = (
-            type(reason) is str and reason in _DEFINITIVE_HERMES_FINALIZE_REASONS
-        )
-        return self.record_session_hook(
-            "on_session_finalize",
-            payload,
-            _record_host_finalize=definitive,
-        )
+        except Exception as exc:
+            self._remember_session_hook_error(hook, exc)
+            raise
+        if receipt is None:
+            self._last_session_hook_error = None
+            return None
+        if isinstance(receipt, SessionHookReceipt):
+            return self._project_session_receipt(hook, receipt)
+        if not isinstance(receipt, SessionTurnTerminalReceipt):
+            raise RuntimeComponentsError(
+                "session owner returned an invalid child terminal receipt"
+            )
+        self._last_session_hook_error = None
+        return receipt
+
+    def record_hermes_session_finalize(self, kwargs: Mapping[str, Any] | None = None):
+        """Normalize Hermes session rotation and shutdown boundaries."""
+
+        hook = "on_session_finalize"
+        payload = {} if kwargs is None else kwargs
+        try:
+            context = self._resolve_session_context(hook, payload)
+            if context is None or self.session.snapshot(context.lifecycle_id) is None:
+                return None
+            disposition = self.hermes_host_adapter.finalize_disposition(payload)
+            if disposition == "shutdown":
+                record_host_shutdown = getattr(
+                    self.session, "record_host_shutdown", None
+                )
+                if not callable(record_host_shutdown):
+                    raise RuntimeComponentsError(
+                        "session owner is missing record_host_shutdown"
+                    )
+                receipt = record_host_shutdown(context)
+                self._last_session_hook_error = None
+                return receipt
+            if disposition == "definitive":
+                record_host_finalize = getattr(
+                    self.session, "record_host_finalize", None
+                )
+                if not callable(record_host_finalize):
+                    raise RuntimeComponentsError(
+                        "session owner is missing record_host_finalize"
+                    )
+                receipt = record_host_finalize(context)
+            else:
+                receipt = self.session.record_hook(
+                    context, "on_session_finalize", settled=False
+                )
+        except SessionHookMappingError as exc:
+            self._remember_session_hook_error(hook, exc)
+            return None
+        except Exception as exc:
+            self._remember_session_hook_error(hook, exc)
+            raise
+        return self._project_session_receipt(hook, receipt)
 
     def _local_reflection(self, context) -> dict[str, Any]:
         facts = dict(context.facts)

--- a/moonbite_plugin/session.py
+++ b/moonbite_plugin/session.py
@@ -29,7 +29,22 @@ SESSION_TURN_TERMINAL_SCHEMA = "moon.session.turn_terminal.v1"
 SESSION_TURN_TERMINAL_KIND = "turn_terminal"
 TURN_TERMINAL_OUTCOMES = frozenset({"abandoned"})
 TURN_TERMINAL_REASONS = frozenset(
-    {"superseded_by_new_pre", "operator_repair", "host_session_finalized"}
+    {
+        "superseded_by_new_pre",
+        "operator_repair",
+        "host_session_finalized",
+        "host_shutdown",
+        "host_turn_completed_without_post",
+        "host_turn_failed",
+        "host_turn_incomplete",
+        "host_turn_interrupted",
+    }
+)
+CHILD_STOP_TERMINAL_REASONS = frozenset(
+    {
+        "host_turn_failed",
+        "host_turn_interrupted",
+    }
 )
 
 HOOK_ORDER = (
@@ -37,7 +52,9 @@ HOOK_ORDER = (
     "on_session_start",
     "pre_llm_call",
     "post_llm_call",
+    "on_session_end",
     "on_session_finalize",
+    "subagent_stop",
 )
 HOOKS = frozenset(HOOK_ORDER)
 SUPPORTED_HOOKS = HOOKS
@@ -74,6 +91,7 @@ _ROW_FIELDS = frozenset(
         "settled",
     }
 )
+_TERMINAL_CALLBACK_ROW_FIELDS = _ROW_FIELDS | {"terminal_reason"}
 _TERMINAL_ROW_FIELDS = frozenset(
     {
         "schema_version",
@@ -348,13 +366,14 @@ class _Callback:
     hook: str
     settled: bool
     event_id: str
+    terminal_reason: str | None = None
 
     @property
     def key(self) -> tuple[str, str, str | None]:
         return (self.hook, self.context.source_id, self.context.turn_id)
 
     def to_row(self) -> dict[str, Any]:
-        return {
+        row = {
             "schema_version": SESSION_LIFECYCLE_SCHEMA,
             "kind": SESSION_LIFECYCLE_KIND,
             "event_id": self.event_id,
@@ -362,6 +381,9 @@ class _Callback:
             "hook": self.hook,
             "settled": self.settled,
         }
+        if self.terminal_reason is not None:
+            row["terminal_reason"] = self.terminal_reason
+        return row
 
 
 @dataclass(slots=True)
@@ -418,6 +440,7 @@ def _same_callback_identity(left: _Callback, right: _Callback) -> bool:
         and left.context.fresh == right.context.fresh
         and left.context.supported_hooks == right.context.supported_hooks
         and left.settled == right.settled
+        and left.terminal_reason == right.terminal_reason
     )
 
 
@@ -459,10 +482,14 @@ class SessionLifecycleStore:
             raise SessionLifecycleError(
                 "post_llm_call requires source_kind=assistant_response"
             )
+        if hook == "on_session_end" and context.source_kind != "system":
+            raise SessionLifecycleError("on_session_end requires source_kind=system")
         if hook == "on_session_finalize" and context.source_kind != "system":
             raise SessionLifecycleError(
                 "on_session_finalize requires source_kind=system"
             )
+        if hook == "subagent_stop" and context.source_kind != "system":
+            raise SessionLifecycleError("subagent_stop requires source_kind=system")
         if hook in {"pre_gateway_dispatch", "pre_llm_call"} and context.source_kind in {
             "session_start",
             "assistant_response",
@@ -563,6 +590,37 @@ class SessionLifecycleStore:
                 state.settled_turn_ids.append(turn_id)
                 state.current_turn_id = None
 
+        elif callback.hook == "on_session_end":
+            turn_id = context.turn_id
+            if turn_id is None:
+                raise SessionLifecycleError("on_session_end requires turn_id")
+            turn = state.turns.get(turn_id)
+            if turn is None:
+                raise SessionLifecycleError("on_session_end requires pre_llm_call")
+            if turn.outcome is None:
+                raise SessionLifecycleError(
+                    "on_session_end requires canonical turn terminal evidence"
+                )
+
+        elif callback.hook == "subagent_stop":
+            turn_id = context.turn_id
+            if turn_id is None:
+                raise SessionLifecycleError("subagent_stop requires turn_id")
+            if callback.terminal_reason not in CHILD_STOP_TERMINAL_REASONS:
+                raise SessionLifecycleError(
+                    "subagent_stop requires a child terminal reason"
+                )
+            turn = state.turns.get(turn_id)
+            terminal = state.terminals.get(turn_id)
+            if turn is None or terminal is None or turn.outcome != "abandoned":
+                raise SessionLifecycleError(
+                    "subagent_stop requires canonical non-success terminal evidence"
+                )
+            if terminal.reason != callback.terminal_reason:
+                raise SessionLifecycleError(
+                    "subagent_stop conflicts with existing terminal evidence"
+                )
+
         elif callback.hook == "on_session_finalize":
             if state.finalized:
                 raise SessionLifecycleError("on_session_finalize already recorded")
@@ -599,7 +657,8 @@ class SessionLifecycleStore:
 
     @staticmethod
     def _callback_from_row(row: Mapping[str, Any]) -> _Callback:
-        if set(row) != _ROW_FIELDS:
+        row_fields = set(row)
+        if row_fields != _ROW_FIELDS and row_fields != _TERMINAL_CALLBACK_ROW_FIELDS:
             raise SessionLifecycleError("session lifecycle row has invalid fields")
         if row["schema_version"] != SESSION_LIFECYCLE_SCHEMA:
             raise SessionLifecycleError(
@@ -619,6 +678,21 @@ class SessionLifecycleStore:
             ) from exc
         if type(hook) is not str or hook not in HOOKS:
             raise SessionLifecycleError("session lifecycle row hook is invalid")
+        terminal_reason = row.get("terminal_reason")
+        if terminal_reason is not None and (
+            hook not in {"on_session_end", "subagent_stop"}
+            or type(terminal_reason) is not str
+            or terminal_reason not in TURN_TERMINAL_REASONS
+            or not terminal_reason.startswith("host_turn_")
+        ):
+            raise SessionLifecycleError("session lifecycle terminal_reason is invalid")
+        if (
+            hook == "subagent_stop"
+            and terminal_reason not in CHILD_STOP_TERMINAL_REASONS
+        ):
+            raise SessionLifecycleError(
+                "session lifecycle child terminal_reason is invalid"
+            )
         raw_turn_id = row["turn_id"]
         if raw_turn_id is not None and type(raw_turn_id) is not str:
             raise SessionLifecycleError("session lifecycle row turn_id is invalid")
@@ -659,6 +733,7 @@ class SessionLifecycleStore:
             hook=hook,
             settled=row["settled"],
             event_id=event_id,
+            terminal_reason=terminal_reason,
         )
 
     @staticmethod
@@ -956,6 +1031,279 @@ class SessionLifecycleStore:
                 reason="operator_repair",
                 superseded_by_turn_id=None,
                 observed_at=effective_observed_at,
+            )
+            self._apply_terminal(state, terminal)
+            self.ledger.append(terminal.to_row())
+            return self._terminal_receipt(terminal, state, deduplicated=False)
+
+    def record_host_turn_end(
+        self,
+        context: SessionContext,
+        terminal_reason: str,
+    ) -> SessionHookReceipt | SessionTurnTerminalReceipt | None:
+        """Record an exact host turn end, abandoning only a still-open turn."""
+
+        self._validate_inputs(context, "on_session_end", False)
+        if (
+            terminal_reason not in TURN_TERMINAL_REASONS
+            or not terminal_reason.startswith("host_turn_")
+        ):
+            raise SessionLifecycleError("unsupported host turn terminal reason")
+        callback = _Callback(
+            context=context,
+            hook="on_session_end",
+            settled=False,
+            event_id=new_id("session_hook"),
+            terminal_reason=terminal_reason,
+        )
+        with file_lock(self.mutation_lock):
+            states = self._replay_unlocked()
+            state = states.get(context.lifecycle_id)
+            if state is None:
+                return None
+
+            turn_id = context.turn_id
+            assert turn_id is not None
+            turn = state.turns.get(turn_id)
+            if turn is None:
+                raise SessionLifecycleError("on_session_end requires pre_llm_call")
+
+            records_hook = "on_session_end" in state.supported_hooks
+            existing_callback = next(
+                (
+                    item
+                    for item in state.callbacks.values()
+                    if item.hook == "on_session_end" and item.context.turn_id == turn_id
+                ),
+                None,
+            )
+            if existing_callback is not None:
+                if not _same_callback_identity(existing_callback, callback):
+                    raise SessionLifecycleError(
+                        "on_session_end conflicts with existing terminal evidence"
+                    )
+                return self._receipt(existing_callback, state, deduplicated=True)
+
+            existing_terminal = state.terminals.get(turn_id)
+            if existing_terminal is not None:
+                if existing_terminal.reason != terminal_reason:
+                    raise SessionLifecycleError(
+                        "on_session_end conflicts with existing terminal evidence"
+                    )
+                if not records_hook:
+                    return self._terminal_receipt(
+                        existing_terminal, state, deduplicated=True
+                    )
+
+            if (
+                turn.outcome == "completed"
+                and terminal_reason != "host_turn_completed_without_post"
+            ):
+                raise SessionLifecycleError(
+                    "on_session_end conflicts with settled turn evidence"
+                )
+
+            terminal: SessionTurnTerminal | None = None
+            if turn.outcome is None:
+                if state.current_turn_id != turn_id:
+                    raise SessionLifecycleError(
+                        "on_session_end turn does not match the current open turn"
+                    )
+                terminal = SessionTurnTerminal(
+                    schema_version=SESSION_TURN_TERMINAL_SCHEMA,
+                    event_id=new_id("session_turn_terminal"),
+                    session_id=state.session_id,
+                    lifecycle_id=state.lifecycle_id,
+                    turn_id=turn_id,
+                    outcome="abandoned",
+                    reason=terminal_reason,
+                    superseded_by_turn_id=None,
+                    observed_at=context.observed_at,
+                )
+                self._apply_terminal(state, terminal)
+
+            if not records_hook:
+                if terminal is None:
+                    return None
+                self.ledger.append(terminal.to_row())
+                return self._terminal_receipt(terminal, state, deduplicated=False)
+
+            self._apply(state, callback, allow_duplicate=False)
+            if terminal is not None:
+                self.ledger.append(terminal.to_row())
+            self.ledger.append(callback.to_row())
+            return self._receipt(callback, state, deduplicated=False)
+
+    def record_host_child_stop(
+        self,
+        child_session_id: str,
+        terminal_reason: str,
+        observed_at: datetime | None = None,
+    ) -> SessionHookReceipt | SessionTurnTerminalReceipt | None:
+        """Close the unique open child turn reported by Hermes.
+
+        A child stop has no parent turn identity.  The child session id is
+        therefore resolved against exactly one durable lifecycle while holding
+        the same mutation lock used by every other lifecycle mutation.
+        """
+
+        _reference(child_session_id, "child_session_id")
+        if terminal_reason not in CHILD_STOP_TERMINAL_REASONS:
+            raise SessionLifecycleError("unsupported child terminal reason")
+        effective_observed_at = utc_now() if observed_at is None else observed_at
+        if not isinstance(effective_observed_at, datetime):
+            raise TypeError("observed_at must be a datetime")
+        effective_observed_at = as_utc(effective_observed_at)
+
+        with file_lock(self.mutation_lock):
+            states = self._replay_unlocked()
+            matches = [
+                state
+                for state in states.values()
+                if state.session_id == child_session_id
+            ]
+            if len(matches) > 1:
+                raise SessionLifecycleError(
+                    "child_session_id matches multiple Moonbite session lifecycles"
+                )
+            if not matches:
+                return None
+            state = matches[0]
+
+            child_callbacks = [
+                callback
+                for callback in state.callbacks.values()
+                if callback.hook == "subagent_stop"
+            ]
+            if len(child_callbacks) > 1:
+                raise SessionLifecycleError(
+                    "child_session_id has multiple subagent_stop callbacks"
+                )
+            if child_callbacks:
+                callback = child_callbacks[0]
+                if callback.terminal_reason != terminal_reason:
+                    raise SessionLifecycleError(
+                        "subagent_stop conflicts with existing terminal evidence"
+                    )
+                turn_id = callback.context.turn_id
+                if turn_id is None:
+                    raise SessionLifecycleError(
+                        "subagent_stop callback has no child turn"
+                    )
+                terminal = state.terminals.get(turn_id)
+                turn = state.turns.get(turn_id)
+                if (
+                    terminal is None
+                    or turn is None
+                    or turn.outcome != "abandoned"
+                    or terminal.reason != terminal_reason
+                ):
+                    raise SessionLifecycleError(
+                        "subagent_stop callback conflicts with terminal evidence"
+                    )
+                return self._receipt(callback, state, deduplicated=True)
+
+            turn_id = state.current_turn_id
+            if turn_id is None:
+                if len(state.turns) != 1:
+                    raise SessionLifecycleError(
+                        "child_session_id does not identify a unique one-shot turn"
+                    )
+                turn_id = next(iter(state.turns))
+            turn = state.turns.get(turn_id)
+            if turn is None:
+                raise SessionLifecycleError("child turn is not present in lifecycle")
+            terminal = state.terminals.get(turn_id)
+            terminal_created = False
+            if turn.outcome == "completed":
+                raise SessionLifecycleError(
+                    "subagent_stop conflicts with settled turn evidence"
+                )
+            if turn.outcome is None:
+                if state.current_turn_id != turn_id:
+                    raise SessionLifecycleError(
+                        "child turn is not the current open turn"
+                    )
+                terminal = SessionTurnTerminal(
+                    schema_version=SESSION_TURN_TERMINAL_SCHEMA,
+                    event_id=new_id("session_turn_terminal"),
+                    session_id=state.session_id,
+                    lifecycle_id=state.lifecycle_id,
+                    turn_id=turn_id,
+                    outcome="abandoned",
+                    reason=terminal_reason,
+                    superseded_by_turn_id=None,
+                    observed_at=effective_observed_at,
+                )
+                self._apply_terminal(state, terminal)
+                terminal_created = True
+            elif terminal is None or terminal.reason != terminal_reason:
+                raise SessionLifecycleError(
+                    "subagent_stop conflicts with existing terminal evidence"
+                )
+
+            if state.finalized:
+                return self._terminal_receipt(
+                    terminal,
+                    state,
+                    deduplicated=True,
+                )
+
+            records_hook = "subagent_stop" in state.supported_hooks
+            if not records_hook:
+                if terminal_created:
+                    self.ledger.append(terminal.to_row())
+                return self._terminal_receipt(
+                    terminal,
+                    state,
+                    deduplicated=not terminal_created,
+                )
+
+            callback_context = SessionContext(
+                session_id=state.session_id,
+                lifecycle_id=state.lifecycle_id,
+                source_id=child_session_id,
+                turn_id=turn_id,
+                source_kind="system",
+                observed_at=effective_observed_at,
+                fresh=False,
+                supported_hooks=state.supported_hooks,
+            )
+            callback = _Callback(
+                context=callback_context,
+                hook="subagent_stop",
+                settled=False,
+                event_id=new_id("session_hook"),
+                terminal_reason=terminal_reason,
+            )
+            self._apply(state, callback, allow_duplicate=False)
+            if terminal_created:
+                self.ledger.append(terminal.to_row())
+            self.ledger.append(callback.to_row())
+            return self._receipt(callback, state, deduplicated=False)
+
+    def record_host_shutdown(
+        self,
+        context: SessionContext,
+    ) -> SessionTurnTerminalReceipt | None:
+        """Close only an in-flight turn while preserving the reusable session."""
+
+        self._validate_inputs(context, "on_session_finalize", False)
+        with file_lock(self.mutation_lock):
+            state = self._replay_unlocked().get(context.lifecycle_id)
+            if state is None or state.current_turn_id is None:
+                return None
+            turn_id = state.current_turn_id
+            terminal = SessionTurnTerminal(
+                schema_version=SESSION_TURN_TERMINAL_SCHEMA,
+                event_id=new_id("session_turn_terminal"),
+                session_id=state.session_id,
+                lifecycle_id=state.lifecycle_id,
+                turn_id=turn_id,
+                outcome="abandoned",
+                reason="host_shutdown",
+                superseded_by_turn_id=None,
+                observed_at=context.observed_at,
             )
             self._apply_terminal(state, terminal)
             self.ledger.append(terminal.to_row())

--- a/moonbite_plugin/session.py
+++ b/moonbite_plugin/session.py
@@ -34,6 +34,8 @@ TURN_TERMINAL_REASONS = frozenset(
         "operator_repair",
         "host_session_finalized",
         "host_shutdown",
+        "host_turn_completed",
+        # Legacy rows remain readable and are never rewritten.
         "host_turn_completed_without_post",
         "host_turn_failed",
         "host_turn_incomplete",
@@ -1095,10 +1097,10 @@ class SessionLifecycleStore:
                         existing_terminal, state, deduplicated=True
                     )
 
-            if (
-                turn.outcome == "completed"
-                and terminal_reason != "host_turn_completed_without_post"
-            ):
+            if turn.outcome == "completed" and terminal_reason not in {
+                "host_turn_completed",
+                "host_turn_completed_without_post",
+            }:
                 raise SessionLifecycleError(
                     "on_session_end conflicts with settled turn evidence"
                 )

--- a/moonbite_plugin/session.py
+++ b/moonbite_plugin/session.py
@@ -48,6 +48,14 @@ CHILD_STOP_TERMINAL_REASONS = frozenset(
         "host_turn_interrupted",
     }
 )
+# Hermes can classify the same max-iteration child as incomplete at session end
+# and failed when the parent aggregates its result.
+_COMPATIBLE_NON_SUCCESS_TERMINAL_REASONS = frozenset(
+    {
+        "host_turn_failed",
+        "host_turn_incomplete",
+    }
+)
 
 HOOK_ORDER = (
     "pre_gateway_dispatch",
@@ -123,6 +131,12 @@ def _reference(value: str, label: str) -> str:
 
 def _ordered_hooks(hooks: frozenset[str]) -> tuple[str, ...]:
     return tuple(hook for hook in HOOK_ORDER if hook in hooks)
+
+
+def _terminal_reasons_compatible(left: str, right: str) -> bool:
+    return left == right or frozenset((left, right)) == (
+        _COMPATIBLE_NON_SUCCESS_TERMINAL_REASONS
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -618,7 +632,9 @@ class SessionLifecycleStore:
                 raise SessionLifecycleError(
                     "subagent_stop requires canonical non-success terminal evidence"
                 )
-            if terminal.reason != callback.terminal_reason:
+            if not _terminal_reasons_compatible(
+                terminal.reason, callback.terminal_reason
+            ):
                 raise SessionLifecycleError(
                     "subagent_stop conflicts with existing terminal evidence"
                 )
@@ -1088,7 +1104,9 @@ class SessionLifecycleStore:
 
             existing_terminal = state.terminals.get(turn_id)
             if existing_terminal is not None:
-                if existing_terminal.reason != terminal_reason:
+                if not _terminal_reasons_compatible(
+                    existing_terminal.reason, terminal_reason
+                ):
                     raise SessionLifecycleError(
                         "on_session_end conflicts with existing terminal evidence"
                     )
@@ -1100,6 +1118,8 @@ class SessionLifecycleStore:
             if turn.outcome == "completed" and terminal_reason not in {
                 "host_turn_completed",
                 "host_turn_completed_without_post",
+                "host_turn_failed",
+                "host_turn_incomplete",
             }:
                 raise SessionLifecycleError(
                     "on_session_end conflicts with settled turn evidence"
@@ -1198,7 +1218,9 @@ class SessionLifecycleStore:
                     terminal is None
                     or turn is None
                     or turn.outcome != "abandoned"
-                    or terminal.reason != terminal_reason
+                    or not _terminal_reasons_compatible(
+                        terminal.reason, terminal_reason
+                    )
                 ):
                     raise SessionLifecycleError(
                         "subagent_stop callback conflicts with terminal evidence"
@@ -1239,7 +1261,9 @@ class SessionLifecycleStore:
                 )
                 self._apply_terminal(state, terminal)
                 terminal_created = True
-            elif terminal is None or terminal.reason != terminal_reason:
+            elif terminal is None or not _terminal_reasons_compatible(
+                terminal.reason, terminal_reason
+            ):
                 raise SessionLifecycleError(
                     "subagent_stop conflicts with existing terminal evidence"
                 )

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -20,4 +20,6 @@ provides_hooks:
   - on_session_start
   - pre_llm_call
   - post_llm_call
+  - on_session_end
   - on_session_finalize
+  - subagent_stop

--- a/scripts/check-hermes-contract.py
+++ b/scripts/check-hermes-contract.py
@@ -185,6 +185,53 @@ def _turn_exit_contract() -> None:
             assert receipt.snapshot.settled_turn_ids == ()
             assert terminal.reason == expected_reason
 
+        shutdown_fallbacks = (
+            {
+                "session_id": "test-session",
+                "task_id": "",
+                "turn_id": "",
+                "api_request_id": "",
+                "completed": False,
+                "interrupted": True,
+                "reason": "keyboard_interrupt",
+                "platform": "cli",
+            },
+            {
+                "session_id": "test-session",
+                "completed": False,
+                "interrupted": True,
+                "reason": "shutdown",
+                "platform": "cli",
+            },
+            {
+                "session_id": "test-session",
+                "completed": False,
+                "interrupted": True,
+                "platform": "tui",
+            },
+        )
+        for index, payload in enumerate(shutdown_fallbacks):
+            store = SessionLifecycleStore(Path(root) / f"shutdown-fallback-{index}")
+            start_turn(store)
+            context = adapter.session_end_shutdown_fallback(
+                payload,
+                supported_hooks=supported,
+            )
+            assert context is not None
+            assert context.turn_id is None
+            context = adapter.correlate_lifecycle(context, store.replay())
+            receipt = store.record_host_shutdown(context)
+            store.record_host_shutdown(context)
+            assert receipt.snapshot.open_turn_id is None
+            assert receipt.snapshot.finalized is False
+            assert receipt.snapshot.abandoned_turn_ids == ("test-turn",)
+            terminal_rows = [
+                row for row in store.ledger.rows() if row["kind"] == "turn_terminal"
+            ]
+            assert len(terminal_rows) == 1
+            assert terminal_rows[0]["turn_id"] == "test-turn"
+            assert terminal_rows[0]["reason"] == "host_shutdown"
+
         child = SessionLifecycleStore(Path(root) / "child-interrupted")
         start_turn(child)
         child_terminal = adapter.subagent_stop_terminal(

--- a/scripts/check-hermes-contract.py
+++ b/scripts/check-hermes-contract.py
@@ -171,7 +171,7 @@ def _turn_exit_contract() -> None:
             ),
             (
                 {"completed": True, "failed": False, "interrupted": False},
-                "host_turn_completed_without_post",
+                "host_turn_completed",
             ),
         )
         for flags, expected_reason in exits:

--- a/scripts/check-hermes-contract.py
+++ b/scripts/check-hermes-contract.py
@@ -6,7 +6,7 @@ import argparse
 import inspect
 import json
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 import subprocess
 import sys
@@ -14,82 +14,258 @@ import tempfile
 import tomllib
 
 import yaml
-from hermes_cli.plugins import PluginContext
+from hermes_cli.hooks import _DEFAULT_PAYLOADS
+from hermes_cli.plugins import PluginContext, VALID_HOOKS
 
 from moonbite_plugin.config import normalize_config
+from moonbite_plugin.hermes_adapter import HermesHostAdapter
 from moonbite_plugin.plugin import TOOL_NAMES
 from moonbite_plugin.session import HOOK_ORDER
-from moonbite_plugin.session import SessionContext, SessionLifecycleStore
+from moonbite_plugin.session import SessionLifecycleStore
 
 
 ROOT = Path(__file__).parents[1]
 PRESETS = ("core-only", "panel-only", "memory-only", "full-companion")
 
 
-def _session_context(
-    source_id: str,
-    *,
-    turn_id: str | None = None,
-    source_kind: str = "system",
-    observed_at: datetime,
-) -> SessionContext:
-    return SessionContext(
-        session_id="contract-session",
-        lifecycle_id="contract-session",
-        source_id=source_id,
-        turn_id=turn_id,
-        source_kind=source_kind,
-        observed_at=observed_at,
-        fresh=False,
-        supported_hooks=frozenset({"pre_llm_call", "post_llm_call"}),
-    )
-
-
 def _turn_exit_contract() -> None:
-    """Exercise host call sequences without depending on a Hermes checkout."""
+    """Exercise the exact turn-terminal payload published by this Hermes."""
 
     now = datetime(2026, 8, 24, 19, 0, tzinfo=UTC)
-    with tempfile.TemporaryDirectory(prefix="moonbite-session-contract-") as root:
-        normal = SessionLifecycleStore(Path(root) / "normal")
-        normal.record_hook(
-            _session_context("pre-normal", turn_id="turn-normal", observed_at=now),
+    adapter = HermesHostAdapter(clock=lambda: now)
+    supported = frozenset(HOOK_ORDER[1:])
+    assert "on_session_end" in VALID_HOOKS
+    assert "subagent_stop" in VALID_HOOKS
+    host_end = dict(_DEFAULT_PAYLOADS["on_session_end"])
+    assert {
+        "session_id",
+        "task_id",
+        "turn_id",
+        "completed",
+        "failed",
+        "interrupted",
+        "turn_exit_reason",
+    } <= host_end.keys()
+
+    host_stop = dict(_DEFAULT_PAYLOADS["subagent_stop"])
+    assert "child_status" in host_stop
+
+    def start_turn(
+        store: SessionLifecycleStore,
+        hooks: frozenset[str] = supported,
+    ) -> None:
+        store.record_hook(
+            adapter.session_context(
+                "on_session_start",
+                {"session_id": "test-session"},
+                hooks,
+            ),
+            "on_session_start",
+        )
+        store.record_hook(
+            adapter.session_context(
+                "pre_llm_call",
+                {
+                    "session_id": "test-session",
+                    "task_id": "test-task",
+                    "turn_id": "test-turn",
+                },
+                hooks,
+            ),
             "pre_llm_call",
         )
+
+    with tempfile.TemporaryDirectory(prefix="moonbite-session-contract-") as root:
+        normal = SessionLifecycleStore(Path(root) / "normal")
+        start_turn(normal)
         normal.record_hook(
-            _session_context(
-                "post-normal",
-                turn_id="turn-normal",
-                source_kind="assistant_response",
-                observed_at=now + timedelta(seconds=1),
+            adapter.session_context(
+                "post_llm_call",
+                {
+                    "session_id": "test-session",
+                    "task_id": "test-task",
+                    "turn_id": "test-turn",
+                },
+                supported,
             ),
             "post_llm_call",
             settled=True,
         )
-        assert normal.snapshot("contract-session").settled_turn_ids == ("turn-normal",)
+        normal_end = adapter.turn_terminal(host_end, supported_hooks=supported)
+        normal.record_host_turn_end(normal_end.context, normal_end.reason)
+        assert normal.snapshot("test-session").settled_turn_ids == ("test-turn",)
 
-        for exit_reason in ("interrupted", "empty-final-response"):
-            store = SessionLifecycleStore(Path(root) / exit_reason)
-            store.record_hook(
-                _session_context(
-                    f"pre-{exit_reason}",
-                    turn_id="turn-abandoned",
-                    observed_at=now,
-                ),
+        rotated = SessionLifecycleStore(Path(root) / "rotated")
+        start_turn(rotated)
+        rotated_post = adapter.correlate_turn(
+            adapter.session_context(
+                "post_llm_call",
+                {
+                    "session_id": "compressed-session",
+                    "task_id": "test-task",
+                    "turn_id": "test-turn",
+                },
+                supported,
+            ),
+            rotated.replay(),
+        )
+        rotated.record_hook(rotated_post, "post_llm_call", settled=True)
+        rotated_payload = {**host_end, "session_id": "compressed-session"}
+        rotated_end = adapter.turn_terminal(
+            rotated_payload,
+            supported_hooks=supported,
+            context=adapter.correlate_turn(
+                adapter.session_context("on_session_end", rotated_payload, supported),
+                rotated.replay(),
+            ),
+        )
+        rotated.record_host_turn_end(rotated_end.context, rotated_end.reason)
+        assert rotated.snapshot("compressed-session") is None
+        assert rotated.snapshot("test-session").settled_turn_ids == ("test-turn",)
+
+        continuation = adapter.pre_turn_context(
+            adapter.session_context(
                 "pre_llm_call",
-            )
-            # Hermes may omit post_llm_call for this host exit.  A successor
-            # pre must still recover the old ownership without a fake post.
-            successor = store.record_hook(
-                _session_context(
-                    f"pre-successor-{exit_reason}",
-                    turn_id="turn-successor",
-                    observed_at=now + timedelta(seconds=1),
+                {
+                    "session_id": "compressed-session",
+                    "task_id": "next-task",
+                    "turn_id": "next-turn",
+                },
+                supported,
+            ),
+            rotated.replay(),
+        )
+        rotated.record_hook(continuation, "pre_llm_call")
+        continuation_end_payload = {
+            **host_end,
+            "session_id": "compressed-session",
+            "task_id": "next-task",
+            "turn_id": "next-turn",
+            "completed": False,
+            "failed": True,
+        }
+        continuation_end = adapter.turn_terminal(
+            continuation_end_payload,
+            supported_hooks=continuation.supported_hooks,
+            context=adapter.correlate_turn(
+                adapter.session_context(
+                    "on_session_end", continuation_end_payload, supported
                 ),
-                "pre_llm_call",
+                rotated.replay(),
+            ),
+        )
+        rotated.record_host_turn_end(continuation_end.context, continuation_end.reason)
+        assert "on_session_start" not in continuation.supported_hooks
+        assert rotated.snapshot("compressed-session").abandoned_turn_ids == (
+            "next-turn",
+        )
+
+        exits = (
+            (
+                {"completed": False, "failed": True, "interrupted": False},
+                "host_turn_failed",
+            ),
+            (
+                {"completed": False, "failed": False, "interrupted": True},
+                "host_turn_interrupted",
+            ),
+            (
+                {"completed": True, "failed": False, "interrupted": False},
+                "host_turn_completed_without_post",
+            ),
+        )
+        for flags, expected_reason in exits:
+            store = SessionLifecycleStore(Path(root) / expected_reason)
+            start_turn(store)
+            payload = {**host_end, **flags}
+            terminal = adapter.turn_terminal(payload, supported_hooks=supported)
+            receipt = store.record_host_turn_end(terminal.context, terminal.reason)
+            assert receipt.snapshot.open_turn_id is None
+            assert receipt.snapshot.abandoned_turn_ids == ("test-turn",)
+            assert receipt.snapshot.settled_turn_ids == ()
+            assert terminal.reason == expected_reason
+
+        child = SessionLifecycleStore(Path(root) / "child-interrupted")
+        start_turn(child)
+        child_terminal = adapter.subagent_stop_terminal(
+            {
+                **host_stop,
+                "child_session_id": "test-session",
+                "child_status": "interrupted",
+            }
+        )
+        assert child_terminal is not None
+        child_receipt = child.record_host_child_stop(
+            child_terminal.child_session_id,
+            child_terminal.reason,
+            now,
+        )
+        child_replay = child.record_host_child_stop(
+            child_terminal.child_session_id,
+            child_terminal.reason,
+            now,
+        )
+        assert child_receipt.snapshot.open_turn_id is None
+        assert child_receipt.snapshot.settled_turn_ids == ()
+        assert child_replay.deduplicated is True
+        late_end = adapter.turn_terminal(
+            {
+                **host_end,
+                "completed": False,
+                "failed": False,
+                "interrupted": True,
+            },
+            supported_hooks=supported,
+        )
+        child.record_host_turn_end(late_end.context, late_end.reason)
+        assert (
+            len([row for row in child.ledger.rows() if row["kind"] == "turn_terminal"])
+            == 1
+        )
+
+        timed_out = SessionLifecycleStore(Path(root) / "child-timeout")
+        start_turn(timed_out)
+        timeout_terminal = adapter.subagent_stop_terminal(
+            {
+                **host_stop,
+                "child_session_id": "test-session",
+                "child_status": "timeout",
+            }
+        )
+        assert timeout_terminal is not None
+        timeout_receipt = timed_out.record_host_child_stop(
+            timeout_terminal.child_session_id,
+            timeout_terminal.reason,
+            now,
+        )
+        assert timeout_terminal.reason == "host_turn_failed"
+        assert timeout_receipt.snapshot.open_turn_id is None
+        timeout_terminals = [
+            row for row in timed_out.ledger.rows() if row["kind"] == "turn_terminal"
+        ]
+        assert len(timeout_terminals) == 1
+        assert timeout_terminals[0]["reason"] == "host_turn_failed"
+        assert (
+            adapter.subagent_stop_terminal(
+                {
+                    **host_stop,
+                    "child_session_id": "test-session",
+                    "child_status": "completed",
+                }
             )
-            assert successor.snapshot.abandoned_turn_ids == ("turn-abandoned",)
-            assert successor.snapshot.open_turn_id == "turn-successor"
-            assert successor.snapshot.settled_turn_ids == ()
+            is None
+        )
+
+        legacy_hooks = supported - {"subagent_stop"}
+        legacy_child = SessionLifecycleStore(Path(root) / "legacy-child")
+        start_turn(legacy_child, legacy_hooks)
+        legacy_receipt = legacy_child.record_host_child_stop(
+            "test-session",
+            "host_turn_failed",
+            now,
+        )
+        assert legacy_receipt.snapshot.supported_hooks == legacy_hooks
+        assert "subagent_stop" not in legacy_receipt.snapshot.hooks
 
 
 def _metadata_contract() -> None:

--- a/scripts/test-clean-install.sh
+++ b/scripts/test-clean-install.sh
@@ -11,7 +11,8 @@ if [[ -z "$uv_bin" ]]; then
   echo "uv is required; set UV_BIN to its absolute path" >&2
   exit 2
 fi
-if [[ ! -d "$hermes_repo/.git" || ! -d "$source_repo/.git" ]]; then
+if ! git -C "$hermes_repo" rev-parse --git-dir >/dev/null 2>&1 \
+  || ! git -C "$source_repo" rev-parse --git-dir >/dev/null 2>&1; then
   echo "HERMES_REPO and MOONBITE_INSTALL_SOURCE must be Git checkouts" >&2
   exit 2
 fi
@@ -174,4 +175,4 @@ fi
 state_after="$("$python" -c 'import hashlib, sys; print(hashlib.file_digest(open(sys.argv[1], "rb"), "sha256").hexdigest())' "$state_ledger")"
 test "$state_before" = "$state_after"
 
-echo "Clean install lifecycle (approved caution): Hermes $actual_hermes, Moonbite $source_commit, disabled/enabled/disabled, 10 tools, 5 hooks, state preserved"
+echo "Clean install lifecycle (approved caution): Hermes $actual_hermes, Moonbite $source_commit, disabled/enabled/disabled, 10 tools, 7 hooks, state preserved"

--- a/scripts/test-clean-wheel.sh
+++ b/scripts/test-clean-wheel.sh
@@ -7,7 +7,8 @@ expected_hermes="${HERMES_EXPECTED_COMMIT:-}"
 uv_bin="${UV_BIN:-$(command -v uv || true)}"
 python_bin="${PYTHON_BIN:-python3}"
 
-if [[ -z "$uv_bin" || ! -d "$hermes_repo/.git" ]]; then
+if [[ -z "$uv_bin" ]] \
+  || ! git -C "$hermes_repo" rev-parse --git-dir >/dev/null 2>&1; then
   echo "uv and an isolated HERMES_REPO checkout are required" >&2
   exit 2
 fi

--- a/scripts/test-hermes-contract.sh
+++ b/scripts/test-hermes-contract.sh
@@ -12,7 +12,7 @@ if [[ -z "$uv_bin" ]]; then
   exit 2
 fi
 
-if [[ ! -d "$hermes_repo/.git" ]]; then
+if ! git -C "$hermes_repo" rev-parse --git-dir >/dev/null 2>&1; then
   git clone --depth 1 https://github.com/NousResearch/hermes-agent.git "$hermes_repo"
 fi
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -34,6 +34,18 @@ class SyntheticSession:
     def record_hook(self, *_args, **_kwargs):
         return None
 
+    def record_host_turn_end(self, *_args, **_kwargs):
+        return None
+
+    def record_host_child_stop(self, *_args, **_kwargs):
+        return None
+
+    def record_host_shutdown(self, *_args, **_kwargs):
+        return None
+
+    def record_host_finalize(self, *_args, **_kwargs):
+        return None
+
     def snapshot(self, *_args, **_kwargs):
         return None
 
@@ -180,6 +192,25 @@ def test_effect_owner_requires_public_read_ports(tmp_path, method):
     effects = SyntheticEffects()
     setattr(effects, method, None)
     values["effects"] = effects
+
+    with pytest.raises(RuntimeComponentsError, match=method):
+        RuntimeComponents(**values)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "record_host_turn_end",
+        "record_host_child_stop",
+        "record_host_shutdown",
+        "record_host_finalize",
+    ],
+)
+def test_session_owner_requires_canonical_terminal_ports(tmp_path, method):
+    values = bundle_kwargs(tmp_path)
+    session = SyntheticSession()
+    setattr(session, method, None)
+    values["session"] = session
 
     with pytest.raises(RuntimeComponentsError, match=method):
         RuntimeComponents(**values)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -151,6 +151,14 @@ def test_standalone_passes_anchor_timezone_to_cadence(tmp_path):
     )
 
 
+def test_previous_runtime_components_schema_is_rejected(tmp_path):
+    values = bundle_kwargs(tmp_path)
+    values["schema_version"] = "moon.runtime_components.v2"
+
+    with pytest.raises(RuntimeComponentsError, match="unsupported runtime components"):
+        RuntimeComponents(**values)
+
+
 def test_injected_preserves_supplied_identities_without_creating_state_root(tmp_path):
     root = tmp_path / "host-state"
     values = bundle_kwargs(tmp_path)

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -78,6 +78,66 @@ def test_host_adapter_completed_turn_uses_neutral_reason():
 
 
 @pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "session_id": "contract-session",
+            "task_id": "",
+            "turn_id": "",
+            "api_request_id": "",
+            "completed": False,
+            "interrupted": True,
+            "reason": "keyboard_interrupt",
+            "platform": "cli",
+        },
+        {
+            "session_id": "contract-session",
+            "completed": False,
+            "interrupted": True,
+            "reason": "shutdown",
+            "platform": "cli",
+        },
+        {
+            "session_id": "contract-session",
+            "completed": False,
+            "interrupted": True,
+            "platform": "tui",
+        },
+    ),
+)
+def test_host_adapter_maps_identifier_poor_shutdown_fallback(payload):
+    adapter = HermesHostAdapter()
+
+    context = adapter.session_end_shutdown_fallback(
+        payload,
+        supported_hooks=frozenset(HOOK_ORDER),
+    )
+
+    assert context is not None
+    assert context.session_id == "contract-session"
+    assert context.lifecycle_id == "contract-session"
+    assert context.source_id == "contract-session"
+    assert context.turn_id is None
+    with pytest.raises(ValueError, match="turn_id is required"):
+        adapter.turn_terminal(
+            payload,
+            supported_hooks=frozenset(HOOK_ORDER),
+        )
+
+
+def test_host_adapter_does_not_treat_exact_turn_end_as_shutdown_fallback():
+    adapter = HermesHostAdapter()
+
+    assert (
+        adapter.session_end_shutdown_fallback(
+            HERMES_TURN_END_PAYLOAD,
+            supported_hooks=frozenset(HOOK_ORDER),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
     ("status", "reason"),
     (
         ("interrupted", "host_turn_interrupted"),

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -60,6 +60,23 @@ def test_host_adapter_normalizes_official_turn_end_payload():
     assert terminal.reason == "host_turn_failed"
 
 
+def test_host_adapter_completed_turn_uses_neutral_reason():
+    adapter = HermesHostAdapter()
+
+    terminal = adapter.turn_terminal(
+        {
+            **HERMES_TURN_END_PAYLOAD,
+            "completed": True,
+            "failed": False,
+            "interrupted": False,
+            "turn_exit_reason": "text_response(stop)",
+        },
+        supported_hooks=frozenset(HOOK_ORDER),
+    )
+
+    assert terminal.reason == "host_turn_completed"
+
+
 @pytest.mark.parametrize(
     ("status", "reason"),
     (
@@ -134,6 +151,40 @@ def test_host_adapter_correlates_rotated_session_from_durable_turn():
     assert correlated.session_id == "session-old"
     assert correlated.lifecycle_id == "session-old"
     assert correlated.turn_id == "contract-turn"
+
+
+def test_host_adapter_correlates_lifecycle_capabilities_from_durable_state():
+    adapter = HermesHostAdapter()
+    context = adapter.session_context(
+        "on_session_finalize",
+        {"session_id": "legacy-session"},
+        frozenset(HOOK_ORDER),
+    )
+    legacy_hooks = frozenset(
+        {
+            "pre_gateway_dispatch",
+            "on_session_start",
+            "pre_llm_call",
+            "post_llm_call",
+            "on_session_finalize",
+        }
+    )
+    snapshot = SessionLifecycleSnapshot(
+        session_id="legacy-session",
+        lifecycle_id="legacy-session",
+        supported_hooks=legacy_hooks,
+        hooks=("on_session_start", "pre_llm_call"),
+        settled_turn_ids=(),
+        open_turn_id=None,
+        finalized=False,
+        private_contact_count=0,
+    )
+
+    correlated = adapter.correlate_lifecycle(context, (snapshot,))
+
+    assert correlated.session_id == "legacy-session"
+    assert correlated.lifecycle_id == "legacy-session"
+    assert correlated.supported_hooks == legacy_hooks
 
 
 def test_host_adapter_rejects_ambiguous_turn_correlation():

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -3,13 +3,30 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
 
+import pytest
+
 from moonbite_plugin.autonomy import AutonomyContext
 from moonbite_plugin.heartbeat import HeartbeatCandidate, JudgeDecision
 from moonbite_plugin.hermes_adapter import (
     HermesDiaryWriter,
+    HermesHostAdapter,
     HermesModelReflection,
     HermesSessionWakeSink,
 )
+from moonbite_plugin.session import HOOK_ORDER, SessionContext, SessionLifecycleSnapshot
+
+
+HERMES_TURN_END_PAYLOAD = {
+    "session_id": "contract-session",
+    "task_id": "contract-task",
+    "turn_id": "contract-turn",
+    "completed": False,
+    "failed": True,
+    "interrupted": False,
+    "turn_exit_reason": "provider_error",
+    "model": "contract-model",
+    "platform": "cli",
+}
 
 
 class Llm:
@@ -27,6 +44,127 @@ class Llm:
         return SimpleNamespace(
             parsed={"title": "Day", "body": "Grounded body.", "reason": "evidence"}
         )
+
+
+def test_host_adapter_normalizes_official_turn_end_payload():
+    adapter = HermesHostAdapter()
+
+    terminal = adapter.turn_terminal(
+        HERMES_TURN_END_PAYLOAD,
+        supported_hooks=frozenset(HOOK_ORDER),
+    )
+
+    assert terminal.context.session_id == "contract-session"
+    assert terminal.context.lifecycle_id == "contract-session"
+    assert terminal.context.turn_id == "contract-turn"
+    assert terminal.reason == "host_turn_failed"
+
+
+@pytest.mark.parametrize(
+    ("status", "reason"),
+    (
+        ("interrupted", "host_turn_interrupted"),
+        ("failed", "host_turn_failed"),
+        ("error", "host_turn_failed"),
+        ("timeout", "host_turn_failed"),
+    ),
+)
+def test_host_adapter_normalizes_child_stop_status(status, reason):
+    adapter = HermesHostAdapter()
+
+    terminal = adapter.subagent_stop_terminal(
+        {
+            "child_session_id": "child-session",
+            "child_status": status,
+            "parent_turn_id": "must-not-be-read",
+            "summary": "must-not-be-read",
+            "goal": "must-not-be-read",
+            "tool_history": "must-not-be-read",
+        }
+    )
+
+    assert terminal.child_session_id == "child-session"
+    assert terminal.reason == reason
+
+
+def test_host_adapter_child_stop_completed_is_noop():
+    adapter = HermesHostAdapter()
+
+    assert (
+        adapter.subagent_stop_terminal(
+            {"child_session_id": "child-session", "child_status": "completed"}
+        )
+        is None
+    )
+
+
+def test_host_adapter_child_stop_rejects_unknown_status():
+    adapter = HermesHostAdapter()
+
+    with pytest.raises(ValueError, match="unsupported child_status"):
+        adapter.subagent_stop_terminal(
+            {"child_session_id": "child-session", "child_status": "cancelled"}
+        )
+
+
+def test_host_adapter_correlates_rotated_session_from_durable_turn():
+    adapter = HermesHostAdapter()
+    context = adapter.session_context(
+        "post_llm_call",
+        {
+            "session_id": "session-new",
+            "task_id": "contract-task",
+            "turn_id": "contract-turn",
+        },
+        frozenset(HOOK_ORDER),
+    )
+    snapshot = SessionLifecycleSnapshot(
+        session_id="session-old",
+        lifecycle_id="session-old",
+        supported_hooks=frozenset(HOOK_ORDER),
+        hooks=("on_session_start", "pre_llm_call"),
+        settled_turn_ids=(),
+        open_turn_id="contract-turn",
+        finalized=False,
+        private_contact_count=0,
+    )
+
+    correlated = adapter.correlate_turn(context, (snapshot,))
+
+    assert correlated.session_id == "session-old"
+    assert correlated.lifecycle_id == "session-old"
+    assert correlated.turn_id == "contract-turn"
+
+
+def test_host_adapter_rejects_ambiguous_turn_correlation():
+    adapter = HermesHostAdapter()
+    context = SessionContext(
+        session_id="session-new",
+        lifecycle_id="session-new",
+        source_id="contract-task",
+        turn_id="contract-turn",
+        source_kind="system",
+        observed_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        fresh=False,
+        supported_hooks=frozenset(HOOK_ORDER),
+    )
+
+    def snapshot(session_id):
+        return SessionLifecycleSnapshot(
+            session_id=session_id,
+            lifecycle_id=session_id,
+            supported_hooks=frozenset(HOOK_ORDER),
+            hooks=("pre_llm_call",),
+            settled_turn_ids=(),
+            open_turn_id="contract-turn",
+            finalized=False,
+            private_contact_count=0,
+        )
+
+    with __import__("pytest").raises(
+        ValueError, match="multiple Moonbite session lifecycles"
+    ):
+        adapter.correlate_turn(context, (snapshot("first"), snapshot("second")))
 
 
 def test_model_reflection_uses_main_task_key():

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -287,6 +287,38 @@ def test_caller_active_chat_cannot_lower_durable_active_chat_gate(tmp_path):
     assert autonomy.reason == "active_chat"
 
 
+def test_caller_active_chat_cannot_be_lowered_by_idle_durable_bridge(tmp_path):
+    runtime = MoonbiteRuntime(
+        {
+            "modules": {"heartbeat": True, "autonomy": True},
+            "heartbeat": {
+                "kinds": {
+                    "fixture": {
+                        "enabled": True,
+                        "profile": "routine",
+                        "judge": "required",
+                        "host_only": False,
+                        "bypass": [],
+                    }
+                }
+            },
+        },
+        root=tmp_path,
+        autonomy_judge=AllowAutonomyJudge(),
+    )
+
+    heartbeat = runtime.run_heartbeat(
+        "fixture",
+        context={"source_event_id": "event-host-active", "active_chat": True},
+    )
+    autonomy = runtime.run_autonomy(
+        facts={"active_chat": True, "chat_active": True}
+    )
+
+    assert heartbeat.reason == "active_chat"
+    assert autonomy.reason == "active_chat"
+
+
 def test_injected_bus_write_failure_propagates_without_local_fallback(
     tmp_path, monkeypatch
 ):

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -38,6 +38,9 @@ from moonbite_plugin.session import (
 )
 
 
+NOW = datetime(2026, 9, 1, 19, 0, tzinfo=UTC)
+
+
 class RecordingLocks:
     def __init__(self):
         self.exclusive_names: list[str] = []
@@ -336,9 +339,7 @@ def test_caller_active_chat_cannot_be_lowered_by_idle_durable_bridge(tmp_path):
         "fixture",
         context={"source_event_id": "event-host-active", "active_chat": True},
     )
-    autonomy = runtime.run_autonomy(
-        facts={"active_chat": True, "chat_active": True}
-    )
+    autonomy = runtime.run_autonomy(facts={"active_chat": True, "chat_active": True})
 
     assert heartbeat.reason == "active_chat"
     assert autonomy.reason == "active_chat"
@@ -697,6 +698,157 @@ def test_plugin_on_session_end_closes_turn_without_fake_post(
         for row in components.session.ledger.rows()
         if row["kind"] == "turn_terminal"
     ] == [expected_reason]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {
+            "session_id": "session-fixture",
+            "task_id": "",
+            "turn_id": "",
+            "api_request_id": "",
+            "completed": False,
+            "interrupted": True,
+            "reason": "keyboard_interrupt",
+            "platform": "cli",
+        },
+        {
+            "session_id": "session-fixture",
+            "completed": False,
+            "interrupted": True,
+            "reason": "shutdown",
+            "platform": "cli",
+        },
+        {
+            "session_id": "session-fixture",
+            "completed": False,
+            "interrupted": True,
+            "platform": "tui",
+        },
+    ),
+)
+def test_plugin_identifier_poor_session_end_closes_durable_open_turn_once(
+    tmp_path, payload
+):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    runtime = register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="session-fixture")
+    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="durable-turn")
+    context.hooks["on_session_end"](**payload)
+    context.hooks["on_session_end"](**payload)
+
+    snapshot = components.session.snapshot("session-fixture")
+    terminal_rows = [
+        row
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ]
+    hook_rows = [
+        row for row in components.session.ledger.rows() if row["kind"] == "hook"
+    ]
+    assert snapshot is not None
+    assert snapshot.open_turn_id is None
+    assert snapshot.finalized is False
+    assert snapshot.abandoned_turn_ids == ("durable-turn",)
+    assert len(terminal_rows) == 1
+    assert terminal_rows[0]["turn_id"] == "durable-turn"
+    assert terminal_rows[0]["reason"] == "host_shutdown"
+    assert "on_session_end" not in [row["hook"] for row in hook_rows]
+    assert runtime.last_session_hook_error is None
+
+    context.hooks["on_session_finalize"](
+        session_id="session-fixture", reason="shutdown"
+    )
+    assert (
+        len(
+            [
+                row
+                for row in components.session.ledger.rows()
+                if row["kind"] == "turn_terminal"
+            ]
+        )
+        == 1
+    )
+
+
+def test_identifier_poor_session_end_does_not_guess_another_lifecycle(tmp_path):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    runtime = register(context, components=components)
+
+    context.hooks["on_session_start"](session_id="known-session")
+    context.hooks["pre_llm_call"](session_id="known-session", turn_id="durable-turn")
+    context.hooks["on_session_end"](
+        session_id="unknown-session",
+        completed=False,
+        interrupted=True,
+        platform="tui",
+    )
+
+    snapshot = components.session.snapshot("known-session")
+    assert snapshot is not None
+    assert snapshot.open_turn_id == "durable-turn"
+    assert not [
+        row
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ]
+    assert runtime.last_session_hook_error == {
+        "hook": "on_session_end",
+        "error": "SessionHookMappingError",
+    }
+
+
+def test_identifier_poor_session_end_uses_injected_lifecycle_mapping(tmp_path):
+    def resolver(hook, kwargs, supported_hooks):
+        return SessionContext(
+            session_id="canonical-session",
+            lifecycle_id="canonical-lifecycle",
+            source_id=kwargs.get("task_id") or f"{hook}:canonical",
+            turn_id=kwargs.get("turn_id") or None,
+            source_kind="session_start" if hook == "on_session_start" else "system",
+            observed_at=NOW,
+            fresh=False,
+            supported_hooks=frozenset(supported_hooks),
+        )
+
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    runtime = MoonbiteRuntime(
+        {},
+        components=components,
+        session_context_resolver=resolver,
+    )
+    runtime.record_session_hook("pre_gateway_dispatch", {"session_id": "host-session"})
+    runtime.record_session_hook("on_session_start", {"session_id": "host-session"})
+    runtime.record_session_hook(
+        "pre_llm_call",
+        {
+            "session_id": "host-session",
+            "task_id": "host-task",
+            "turn_id": "durable-turn",
+        },
+    )
+
+    receipt = runtime.record_hermes_turn_end(
+        {
+            "session_id": "host-session",
+            "completed": False,
+            "interrupted": True,
+            "platform": "tui",
+        }
+    )
+
+    snapshot = components.session.snapshot("canonical-lifecycle")
+    assert receipt is not None
+    assert receipt.turn_id == "durable-turn"
+    assert receipt.reason == "host_shutdown"
+    assert snapshot is not None
+    assert snapshot.open_turn_id is None
+    assert snapshot.finalized is False
+    assert runtime.last_session_hook_error is None
 
 
 def test_turn_end_releases_durable_active_chat_gate(tmp_path):

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -34,6 +34,7 @@ from moonbite_plugin.session import (
     SessionContext,
     SessionLifecycleError,
     SessionLifecycleStore,
+    SessionTurnTerminalReceipt,
 )
 
 
@@ -515,13 +516,24 @@ def test_registered_session_hooks_are_ordered_and_default_source_isolation(tmp_p
         model="fixture",
         platform="cli",
     )
+    context.hooks["on_session_end"](
+        session_id="session-fixture",
+        task_id="task-fixture",
+        turn_id="turn-fixture",
+        completed=True,
+        failed=False,
+        interrupted=False,
+        turn_exit_reason="text_response(stop)",
+        model="fixture",
+        platform="cli",
+    )
     context.hooks["on_session_finalize"](
         session_id="session-fixture", platform="cli", reason="fixture"
     )
 
     snapshot = components.session.snapshot("session-fixture")
     assert snapshot is not None
-    assert snapshot.hooks == HOOK_ORDER[1:]
+    assert snapshot.hooks == HOOK_ORDER[1:-1]
     assert snapshot.private_contact_count == 0
     assert not components.panel.path.exists()
     assert "private body" not in components.session.ledger.path.read_text(
@@ -559,7 +571,7 @@ def test_plugin_session_expired_finalize_closes_open_turn(tmp_path, reason, comp
     ] == ([] if complete else ["host_session_finalized"])
 
 
-def test_plugin_shutdown_finalize_is_noop_and_successor_pre_repairs_old_turn(tmp_path):
+def test_plugin_shutdown_closes_only_open_turn_and_session_remains_reusable(tmp_path):
     components, _locks, _bus = injected_bundle(tmp_path / "host")
     context = RecordingContext()
     register(context, components=components)
@@ -583,7 +595,240 @@ def test_plugin_shutdown_finalize_is_noop_and_successor_pre_repairs_old_turn(tmp
         row["reason"]
         for row in components.session.ledger.rows()
         if row["kind"] == "turn_terminal"
-    ] == ["superseded_by_new_pre"]
+    ] == ["host_shutdown"]
+
+
+@pytest.mark.parametrize(
+    ("flags", "expected_reason"),
+    (
+        ((False, True, False), "host_turn_failed"),
+        ((False, False, True), "host_turn_interrupted"),
+        ((True, False, False), "host_turn_completed_without_post"),
+    ),
+)
+def test_plugin_on_session_end_closes_turn_without_fake_post(
+    tmp_path, flags, expected_reason
+):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    context = RecordingContext()
+    register(context, components=components)
+    completed, failed, interrupted = flags
+
+    context.hooks["on_session_start"](session_id="session-fixture")
+    context.hooks["pre_llm_call"](
+        session_id="session-fixture", task_id="task-fixture", turn_id="turn-fixture"
+    )
+    context.hooks["on_session_end"](
+        session_id="session-fixture",
+        task_id="task-fixture",
+        turn_id="turn-fixture",
+        completed=completed,
+        failed=failed,
+        interrupted=interrupted,
+        turn_exit_reason="contract-exit",
+        model="fixture",
+        platform="cli",
+    )
+
+    snapshot = components.session.snapshot("session-fixture")
+    assert snapshot.open_turn_id is None
+    assert snapshot.settled_turn_ids == ()
+    assert snapshot.abandoned_turn_ids == ("turn-fixture",)
+    assert snapshot.hooks[-1] == "on_session_end"
+    assert [
+        row["reason"]
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == [expected_reason]
+
+
+def test_turn_end_releases_durable_active_chat_gate(tmp_path):
+    def resolver(hook, kwargs, supported_hooks):
+        return SessionContext(
+            session_id="session-fixture",
+            lifecycle_id="session-fixture",
+            source_id=kwargs.get("task_id") or f"{hook}:fixture",
+            turn_id=kwargs.get("turn_id"),
+            source_kind=(
+                "private_inbound"
+                if hook == "pre_gateway_dispatch"
+                else "session_start"
+                if hook == "on_session_start"
+                else "assistant_response"
+                if hook == "post_llm_call"
+                else "system"
+            ),
+            observed_at=datetime(2026, 9, 1, 19, 0, tzinfo=UTC),
+            fresh=hook == "pre_gateway_dispatch",
+            supported_hooks=frozenset(supported_hooks),
+        )
+
+    runtime = MoonbiteRuntime({}, root=tmp_path, session_context_resolver=resolver)
+    runtime.record_session_hook(
+        "pre_gateway_dispatch", {"event": SimpleNamespace(internal=False)}
+    )
+    runtime.record_session_hook("on_session_start", {"session_id": "session-fixture"})
+    runtime.record_session_hook(
+        "pre_llm_call",
+        {
+            "session_id": "session-fixture",
+            "task_id": "task-fixture",
+            "turn_id": "turn-fixture",
+        },
+    )
+    assert runtime.conversation_bridge.snapshots()[0].active_chat is True
+
+    runtime.record_hermes_turn_end(
+        {
+            "session_id": "session-fixture",
+            "task_id": "task-fixture",
+            "turn_id": "turn-fixture",
+            "completed": False,
+            "failed": True,
+            "interrupted": False,
+            "turn_exit_reason": "provider_error",
+        }
+    )
+
+    snapshot = runtime.conversation_bridge.snapshots()[0]
+    assert snapshot.open_turn_id is None
+    assert snapshot.active_chat is False
+
+
+@pytest.mark.parametrize("with_post", (False, True))
+def test_compression_session_rotation_correlates_terminal_to_original_turn(
+    tmp_path, with_post
+):
+    runtime = MoonbiteRuntime({}, root=tmp_path)
+    runtime.record_session_hook("on_session_start", {"session_id": "session-old"})
+    runtime.record_session_hook(
+        "pre_llm_call",
+        {
+            "session_id": "session-old",
+            "task_id": "task-fixture",
+            "turn_id": "turn-fixture",
+        },
+    )
+    if with_post:
+        runtime.record_session_hook(
+            "post_llm_call",
+            {
+                "session_id": "session-new",
+                "task_id": "task-fixture",
+                "turn_id": "turn-fixture",
+            },
+            settled=True,
+        )
+    runtime.record_hermes_turn_end(
+        {
+            "session_id": "session-new",
+            "task_id": "task-fixture",
+            "turn_id": "turn-fixture",
+            "completed": with_post,
+            "failed": not with_post,
+            "interrupted": False,
+            "turn_exit_reason": (
+                "text_response(stop)" if with_post else "compression_failure"
+            ),
+        }
+    )
+
+    original = runtime.session.snapshot("session-old")
+    assert runtime.session.snapshot("session-new") is None
+    assert original.open_turn_id is None
+    assert original.settled_turn_ids == (("turn-fixture",) if with_post else ())
+    assert original.abandoned_turn_ids == (() if with_post else ("turn-fixture",))
+    assert original.hooks[-1] == "on_session_end"
+
+    runtime.record_session_hook(
+        "pre_llm_call",
+        {
+            "session_id": "session-new",
+            "task_id": "task-next",
+            "turn_id": "turn-next",
+        },
+    )
+    runtime.record_hermes_turn_end(
+        {
+            "session_id": "session-new",
+            "task_id": "task-next",
+            "turn_id": "turn-next",
+            "completed": False,
+            "failed": True,
+            "interrupted": False,
+            "turn_exit_reason": "provider_error",
+        }
+    )
+    rotated = runtime.session.snapshot("session-new")
+    assert "on_session_start" not in rotated.supported_hooks
+    assert rotated.open_turn_id is None
+    assert rotated.abandoned_turn_ids == ("turn-next",)
+
+
+def test_upgraded_host_closes_and_reuses_legacy_five_hook_lifecycle(tmp_path):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+    legacy_hooks = frozenset(
+        {
+            "pre_gateway_dispatch",
+            "on_session_start",
+            "pre_llm_call",
+            "post_llm_call",
+            "on_session_finalize",
+        }
+    )
+
+    def legacy_context(hook, turn_id=None):
+        return SessionContext(
+            session_id="legacy-session",
+            lifecycle_id="legacy-session",
+            source_id=turn_id or "legacy-session",
+            turn_id=turn_id,
+            source_kind="session_start" if hook == "on_session_start" else "system",
+            observed_at=datetime(2026, 9, 1, 19, 0, tzinfo=UTC),
+            fresh=hook == "on_session_start",
+            supported_hooks=legacy_hooks,
+        )
+
+    components.session.record_hook(
+        legacy_context("pre_gateway_dispatch"), "pre_gateway_dispatch"
+    )
+    components.session.record_hook(
+        legacy_context("on_session_start"), "on_session_start"
+    )
+    components.session.record_hook(
+        legacy_context("pre_llm_call", "legacy-turn"), "pre_llm_call"
+    )
+    runtime = MoonbiteRuntime({}, components=components)
+
+    terminal = runtime.record_hermes_turn_end(
+        {
+            "session_id": "legacy-session",
+            "task_id": "legacy-task",
+            "turn_id": "legacy-turn",
+            "completed": False,
+            "failed": True,
+            "interrupted": False,
+            "turn_exit_reason": "provider_error",
+        }
+    )
+
+    assert isinstance(terminal, SessionTurnTerminalReceipt)
+    snapshot = components.session.snapshot("legacy-session")
+    assert snapshot.open_turn_id is None
+    assert snapshot.abandoned_turn_ids == ("legacy-turn",)
+    assert "on_session_end" not in snapshot.hooks
+
+    runtime.record_session_hook(
+        "pre_llm_call",
+        {
+            "session_id": "legacy-session",
+            "task_id": "legacy-task-next",
+            "turn_id": "legacy-turn-next",
+        },
+    )
+    assert components.session.snapshot("legacy-session").open_turn_id == (
+        "legacy-turn-next"
+    )
 
 
 def test_plugin_new_session_finalize_closes_old_session_only(tmp_path):
@@ -621,7 +866,7 @@ def test_plugin_new_session_finalize_closes_old_session_only(tmp_path):
     assert new_snapshot.abandoned_turn_ids == ()
 
 
-@pytest.mark.parametrize("reason", (None, "other", ["shutdown"]))
+@pytest.mark.parametrize("reason", (None, "other"))
 def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
     tmp_path, reason
 ):
@@ -641,19 +886,7 @@ def test_plugin_non_definitive_hermes_finalize_keeps_bare_fail_closed_behavior(
     assert all(row["kind"] != "turn_terminal" for row in rows)
 
 
-@pytest.mark.parametrize(
-    ("reason", "extra"),
-    (
-        ("session_expired", {}),
-        (
-            "new_session",
-            {"old_session_id": "session-fixture", "new_session_id": "session-new"},
-        ),
-    ),
-)
-def test_definitive_finalize_falls_back_for_legacy_session_owner(
-    tmp_path, reason, extra
-):
+def test_runtime_requires_canonical_terminal_capabilities(tmp_path):
     components, _locks, _bus = injected_bundle(tmp_path / "host")
     underlying_session = components.session
     legacy_session = SimpleNamespace(
@@ -661,20 +894,11 @@ def test_definitive_finalize_falls_back_for_legacy_session_owner(
         snapshot=underlying_session.snapshot,
         replay=underlying_session.replay,
     )
-    components = replace(components, session=legacy_session)
-    context = RecordingContext()
-    register(context, components=components)
-
-    context.hooks["on_session_start"](session_id="session-fixture")
-    context.hooks["pre_llm_call"](session_id="session-fixture", turn_id="turn-fixture")
-    with pytest.raises(SessionLifecycleError, match="settled"):
-        context.hooks["on_session_finalize"](
-            session_id="session-fixture", reason=reason, **extra
-        )
+    with pytest.raises(RuntimeComponentsError, match="record_host_turn_end"):
+        replace(components, session=legacy_session)
 
     rows = underlying_session.ledger.rows()
-    assert len(rows) == 2
-    assert all(row["kind"] != "turn_terminal" for row in rows)
+    assert rows == []
 
 
 def test_resolver_can_supply_authorized_private_gateway_context(tmp_path):

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -603,7 +603,7 @@ def test_plugin_shutdown_closes_only_open_turn_and_session_remains_reusable(tmp_
     (
         ((False, True, False), "host_turn_failed"),
         ((False, False, True), "host_turn_interrupted"),
-        ((True, False, False), "host_turn_completed_without_post"),
+        ((True, False, False), "host_turn_completed"),
     ),
 )
 def test_plugin_on_session_end_closes_turn_without_fake_post(
@@ -829,6 +829,96 @@ def test_upgraded_host_closes_and_reuses_legacy_five_hook_lifecycle(tmp_path):
     assert components.session.snapshot("legacy-session").open_turn_id == (
         "legacy-turn-next"
     )
+
+
+@pytest.mark.parametrize(
+    "legacy_hooks",
+    (
+        frozenset(
+            {
+                "pre_gateway_dispatch",
+                "on_session_start",
+                "pre_llm_call",
+                "post_llm_call",
+                "on_session_finalize",
+            }
+        ),
+        frozenset(
+            {
+                "on_session_start",
+                "pre_llm_call",
+                "post_llm_call",
+                "on_session_finalize",
+            }
+        ),
+    ),
+)
+@pytest.mark.parametrize("reason", ("session_expired", "new_session"))
+@pytest.mark.parametrize("with_post", (False, True))
+def test_upgraded_host_finalizes_legacy_lifecycle_with_current_hooks(
+    tmp_path, legacy_hooks, reason, with_post
+):
+    components, _locks, _bus = injected_bundle(tmp_path / "host")
+
+    def legacy_context(hook, source_id, turn_id=None):
+        source_kind = {
+            "pre_gateway_dispatch": "private_inbound",
+            "on_session_start": "session_start",
+            "post_llm_call": "assistant_response",
+        }.get(hook, "system")
+        return SessionContext(
+            session_id="legacy-session",
+            lifecycle_id="legacy-session",
+            source_id=source_id,
+            turn_id=turn_id,
+            source_kind=source_kind,
+            observed_at=datetime(2026, 9, 1, 19, 0, tzinfo=UTC),
+            fresh=hook in {"pre_gateway_dispatch", "on_session_start"},
+            supported_hooks=legacy_hooks,
+        )
+
+    if "pre_gateway_dispatch" in legacy_hooks:
+        components.session.record_hook(
+            legacy_context("pre_gateway_dispatch", "legacy-gateway"),
+            "pre_gateway_dispatch",
+        )
+    components.session.record_hook(
+        legacy_context("on_session_start", "legacy-session"),
+        "on_session_start",
+    )
+    components.session.record_hook(
+        legacy_context("pre_llm_call", "legacy-turn", "legacy-turn"),
+        "pre_llm_call",
+    )
+    if with_post:
+        components.session.record_hook(
+            legacy_context("post_llm_call", "legacy-turn", "legacy-turn"),
+            "post_llm_call",
+            settled=True,
+        )
+
+    runtime = MoonbiteRuntime({}, components=components)
+    runtime.record_hermes_session_finalize(
+        {
+            "session_id": "legacy-session",
+            "reason": reason,
+            "old_session_id": "legacy-session",
+            "new_session_id": "new-session" if reason == "new_session" else None,
+        }
+    )
+
+    snapshot = components.session.snapshot("legacy-session")
+    assert snapshot is not None
+    assert snapshot.finalized is True
+    assert snapshot.supported_hooks == legacy_hooks
+    assert snapshot.open_turn_id is None
+    assert snapshot.settled_turn_ids == (("legacy-turn",) if with_post else ())
+    assert snapshot.abandoned_turn_ids == (() if with_post else ("legacy-turn",))
+    assert [
+        row["reason"]
+        for row in components.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ([] if with_post else ["host_session_finalized"])
 
 
 def test_plugin_new_session_finalize_closes_old_session_only(tmp_path):

--- a/tests/test_mb45_wiring.py
+++ b/tests/test_mb45_wiring.py
@@ -255,6 +255,11 @@ def test_concrete_conversation_bridge_must_use_injected_session_and_effect_owner
 
 
 def test_caller_active_chat_cannot_lower_durable_active_chat_gate(tmp_path):
+    class PrivateTurnBridge:
+        @staticmethod
+        def snapshots():
+            return [SimpleNamespace(active_chat=True, last_private_at=NOW)]
+
     runtime = MoonbiteRuntime(
         {
             "modules": {"heartbeat": True, "autonomy": True},
@@ -272,10 +277,7 @@ def test_caller_active_chat_cannot_lower_durable_active_chat_gate(tmp_path):
         },
         root=tmp_path,
         autonomy_judge=AllowAutonomyJudge(),
-    )
-    runtime.record_session_hook("on_session_start", {"session_id": "active"})
-    runtime.record_session_hook(
-        "pre_llm_call", {"session_id": "active", "turn_id": "turn-active"}
+        conversation_bridge=PrivateTurnBridge(),
     )
 
     heartbeat = runtime.run_heartbeat(
@@ -285,6 +287,29 @@ def test_caller_active_chat_cannot_lower_durable_active_chat_gate(tmp_path):
 
     assert heartbeat.reason == "active_chat"
     assert autonomy.reason == "active_chat"
+
+
+def test_internal_open_turn_without_private_input_is_not_chat_presence(tmp_path):
+    class InternalTurnBridge:
+        @staticmethod
+        def snapshots():
+            return [SimpleNamespace(active_chat=True, last_private_at=None)]
+
+    runtime = MoonbiteRuntime(
+        {"modules": {"autonomy": True}},
+        root=tmp_path,
+        conversation_bridge=InternalTurnBridge(),
+    )
+
+    result = runtime.run_autonomy(
+        facts={
+            "active_chat": False,
+            "source_event_id": "internal-turn-source",
+            "epoch_id": "internal-turn-epoch",
+        }
+    )
+
+    assert (result.status, result.reason) == ("skipped", "no_eligible_provider")
 
 
 def test_caller_active_chat_cannot_be_lowered_by_idle_durable_bridge(tmp_path):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -107,6 +107,45 @@ def test_register_passes_injected_conversation_bridge(monkeypatch, tmp_path):
     assert bridge.receipts[0].context.session_id == "bridge-session"
 
 
+def test_registered_subagent_stop_closes_child_turn(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    ctx = FakeContext()
+    runtime = register(ctx)
+
+    ctx.hooks["on_session_start"](session_id="child-session")
+    ctx.hooks["pre_llm_call"](
+        session_id="child-session",
+        turn_id="child-turn",
+    )
+    ctx.hooks["subagent_stop"](
+        child_session_id="child-session",
+        child_status="timeout",
+        parent_turn_id="ignored",
+        summary="ignored",
+        goal="ignored",
+        tool_history="ignored",
+    )
+
+    snapshot = runtime.session.snapshot("child-session")
+    assert snapshot.open_turn_id is None
+    assert snapshot.abandoned_turn_ids == ("child-turn",)
+    assert snapshot.settled_turn_ids == ()
+    assert [
+        row["hook"] for row in runtime.session.ledger.rows() if row["kind"] == "hook"
+    ] == [
+        "on_session_start",
+        "pre_llm_call",
+        "subagent_stop",
+    ]
+    assert [
+        row["reason"]
+        for row in runtime.session.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == [
+        "host_turn_failed",
+    ]
+
+
 def test_register_passes_memory_injection_seams(monkeypatch, tmp_path):
     import moonbite_plugin.plugin as plugin_module
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -138,7 +138,7 @@ def test_full_path_requires_settled_turn_before_finalize(tmp_path) -> None:
     receipts.append(
         store.record_host_turn_end(
             context("end", source_kind="system", turn_id="turn-1"),
-            "host_turn_completed_without_post",
+            "host_turn_completed",
         )
     )
     receipts.append(
@@ -181,7 +181,7 @@ def test_cli_like_order_can_omit_gateway(tmp_path) -> None:
             turn_id="turn-1",
             supported_hooks=supported,
         ),
-        "host_turn_completed_without_post",
+        "host_turn_completed",
     )
     receipt = store.record_hook(
         context("finalize", source_kind="system", supported_hooks=supported),
@@ -196,7 +196,7 @@ def test_cli_like_order_can_omit_gateway(tmp_path) -> None:
     (
         "host_turn_failed",
         "host_turn_interrupted",
-        "host_turn_completed_without_post",
+        "host_turn_completed",
         "host_turn_incomplete",
     ),
 )
@@ -219,6 +219,26 @@ def test_host_turn_end_is_terminal_without_faking_post(tmp_path, reason) -> None
     assert replay.deduplicated is True
 
 
+def test_legacy_completed_terminal_reason_remains_readable(tmp_path) -> None:
+    store = open_turn_store(tmp_path)
+    end = context(
+        "end",
+        source_kind="system",
+        turn_id="turn-1",
+        supported_hooks=FINALIZE_HOOKS,
+    )
+
+    store.record_host_turn_end(end, "host_turn_completed_without_post")
+    replay = SessionLifecycleStore(tmp_path).replay()
+
+    assert replay[0].abandoned_turn_ids == ("turn-1",)
+    assert [
+        row["reason"]
+        for row in store.ledger.rows()
+        if row["kind"] == "turn_terminal"
+    ] == ["host_turn_completed_without_post"]
+
+
 def test_host_turn_end_rejects_conflicting_terminal_classification(tmp_path) -> None:
     store = open_turn_store(tmp_path)
     end = context(
@@ -231,7 +251,7 @@ def test_host_turn_end_rejects_conflicting_terminal_classification(tmp_path) -> 
     store.record_host_turn_end(end, "host_turn_failed")
 
     with pytest.raises(SessionLifecycleError, match="conflicts"):
-        store.record_host_turn_end(end, "host_turn_completed_without_post")
+        store.record_host_turn_end(end, "host_turn_completed")
     assert store.ledger.rows()[-1]["terminal_reason"] == "host_turn_failed"
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -233,9 +233,7 @@ def test_legacy_completed_terminal_reason_remains_readable(tmp_path) -> None:
 
     assert replay[0].abandoned_turn_ids == ("turn-1",)
     assert [
-        row["reason"]
-        for row in store.ledger.rows()
-        if row["kind"] == "turn_terminal"
+        row["reason"] for row in store.ledger.rows() if row["kind"] == "turn_terminal"
     ] == ["host_turn_completed_without_post"]
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -253,6 +253,46 @@ def test_host_turn_end_rejects_conflicting_terminal_classification(tmp_path) -> 
     assert store.ledger.rows()[-1]["terminal_reason"] == "host_turn_failed"
 
 
+@pytest.mark.parametrize(
+    "reason",
+    ("host_turn_incomplete", "host_turn_failed"),
+)
+def test_settled_post_accepts_canonical_non_success_classification(
+    tmp_path, reason
+) -> None:
+    store = open_turn_store(tmp_path)
+    store.record_hook(
+        context(
+            "post",
+            source_kind="assistant_response",
+            turn_id="turn-1",
+            supported_hooks=FINALIZE_HOOKS,
+        ),
+        "post_llm_call",
+        settled=True,
+    )
+
+    receipt = store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=FINALIZE_HOOKS,
+        ),
+        reason,
+    )
+
+    assert receipt.hook == "on_session_end"
+    assert receipt.snapshot.settled_turn_ids == ("turn-1",)
+    assert receipt.snapshot.abandoned_turn_ids == ()
+    assert [row for row in store.ledger.rows() if row["kind"] == "turn_terminal"] == []
+    assert store.ledger.rows()[-1]["hook"] == "on_session_end"
+    assert store.ledger.rows()[-1]["terminal_reason"] == reason
+    assert SessionLifecycleStore(tmp_path).snapshot("lifecycle-1").settled_turn_ids == (
+        "turn-1",
+    )
+
+
 def test_child_stop_first_and_session_end_later_share_one_terminal(tmp_path) -> None:
     store = open_child_store(tmp_path)
 
@@ -313,6 +353,62 @@ def test_session_end_first_and_child_stop_later_add_one_callback(tmp_path) -> No
         for row in store.ledger.rows()
         if row["kind"] == "hook" and row["hook"] == "subagent_stop"
     ] == ["subagent_stop"]
+
+
+def test_session_end_incomplete_then_child_stop_failed_keeps_first_terminal(
+    tmp_path,
+) -> None:
+    store = open_child_store(tmp_path)
+    store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=ALL_HOOKS,
+        ),
+        "host_turn_incomplete",
+    )
+
+    child = store.record_host_child_stop("session-1", "host_turn_failed")
+    replay = store.record_host_child_stop("session-1", "host_turn_failed")
+
+    terminal_rows = [
+        row for row in store.ledger.rows() if row["kind"] == "turn_terminal"
+    ]
+    assert child.hook == "subagent_stop"
+    assert replay.deduplicated is True
+    assert [row["reason"] for row in terminal_rows] == ["host_turn_incomplete"]
+    assert store.ledger.rows()[-1]["terminal_reason"] == "host_turn_failed"
+    assert SessionLifecycleStore(tmp_path).snapshot(
+        "lifecycle-1"
+    ).abandoned_turn_ids == ("turn-1",)
+
+
+def test_child_stop_failed_then_session_end_incomplete_keeps_first_terminal(
+    tmp_path,
+) -> None:
+    store = open_child_store(tmp_path)
+    store.record_host_child_stop("session-1", "host_turn_failed")
+
+    end = store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=ALL_HOOKS,
+        ),
+        "host_turn_incomplete",
+    )
+
+    terminal_rows = [
+        row for row in store.ledger.rows() if row["kind"] == "turn_terminal"
+    ]
+    assert end.hook == "on_session_end"
+    assert [row["reason"] for row in terminal_rows] == ["host_turn_failed"]
+    assert store.ledger.rows()[-1]["terminal_reason"] == "host_turn_incomplete"
+    assert SessionLifecycleStore(tmp_path).snapshot(
+        "lifecycle-1"
+    ).abandoned_turn_ids == ("turn-1",)
 
 
 def test_child_stop_after_finalized_terminal_is_idempotent(tmp_path) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -16,6 +16,7 @@ from moonbite_plugin.session import (
     SessionContext,
     SessionLifecycleError,
     SessionLifecycleStore,
+    SessionTurnTerminalReceipt,
 )
 
 NOW = datetime(2026, 8, 24, 19, 0, tzinfo=UTC)
@@ -54,6 +55,29 @@ def open_turn_store(root):
     )
     store.record_hook(
         context("pre", turn_id="turn-1", supported_hooks=FINALIZE_HOOKS),
+        "pre_llm_call",
+    )
+    return store
+
+
+def open_child_store(root, supported_hooks=ALL_HOOKS):
+    store = SessionLifecycleStore(root)
+    if "pre_gateway_dispatch" in supported_hooks:
+        store.record_hook(
+            context("gateway", supported_hooks=supported_hooks),
+            "pre_gateway_dispatch",
+        )
+    if "on_session_start" in supported_hooks:
+        store.record_hook(
+            context(
+                "start",
+                source_kind="session_start",
+                supported_hooks=supported_hooks,
+            ),
+            "on_session_start",
+        )
+    store.record_hook(
+        context("pre", turn_id="turn-1", supported_hooks=supported_hooks),
         "pre_llm_call",
     )
     return store
@@ -107,16 +131,26 @@ def test_full_path_requires_settled_turn_before_finalize(tmp_path) -> None:
             HOOK_ORDER[3],
             True,
         ),
-        (context("finalize", source_kind="system"), HOOK_ORDER[4], False),
     ]
     receipts = [
         store.record_hook(item, hook, settled=settled) for item, hook, settled in calls
     ]
-    assert [receipt.hook for receipt in receipts] == list(HOOK_ORDER)
+    receipts.append(
+        store.record_host_turn_end(
+            context("end", source_kind="system", turn_id="turn-1"),
+            "host_turn_completed_without_post",
+        )
+    )
+    receipts.append(
+        store.record_hook(
+            context("finalize", source_kind="system"), "on_session_finalize"
+        )
+    )
+    assert [receipt.hook for receipt in receipts] == list(HOOK_ORDER[:-1])
     assert receipts[-1].schema_version == SESSION_LIFECYCLE_SCHEMA
     assert receipts[-1].snapshot.finalized is True
     assert receipts[-1].snapshot.settled_turn_ids == ("turn-1",)
-    assert len(store.ledger.rows()) == 5
+    assert len(store.ledger.rows()) == 6
 
 
 def test_cli_like_order_can_omit_gateway(tmp_path) -> None:
@@ -140,12 +174,214 @@ def test_cli_like_order_can_omit_gateway(tmp_path) -> None:
         "post_llm_call",
         settled=True,
     )
+    store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=supported,
+        ),
+        "host_turn_completed_without_post",
+    )
     receipt = store.record_hook(
         context("finalize", source_kind="system", supported_hooks=supported),
         "on_session_finalize",
     )
     assert receipt.snapshot.finalized is True
-    assert receipt.snapshot.hooks == HOOK_ORDER[1:]
+    assert receipt.snapshot.hooks == HOOK_ORDER[1:-1]
+
+
+@pytest.mark.parametrize(
+    "reason",
+    (
+        "host_turn_failed",
+        "host_turn_interrupted",
+        "host_turn_completed_without_post",
+        "host_turn_incomplete",
+    ),
+)
+def test_host_turn_end_is_terminal_without_faking_post(tmp_path, reason) -> None:
+    store = open_turn_store(tmp_path)
+    end = context(
+        "end",
+        source_kind="system",
+        turn_id="turn-1",
+        supported_hooks=FINALIZE_HOOKS,
+    )
+
+    receipt = store.record_host_turn_end(end, reason)
+    replay = store.record_host_turn_end(end, reason)
+
+    assert receipt.snapshot.open_turn_id is None
+    assert receipt.snapshot.settled_turn_ids == ()
+    assert receipt.snapshot.abandoned_turn_ids == ("turn-1",)
+    assert receipt.snapshot.hooks[-1] == "on_session_end"
+    assert replay.deduplicated is True
+
+
+def test_host_turn_end_rejects_conflicting_terminal_classification(tmp_path) -> None:
+    store = open_turn_store(tmp_path)
+    end = context(
+        "end",
+        source_kind="system",
+        turn_id="turn-1",
+        supported_hooks=FINALIZE_HOOKS,
+    )
+
+    store.record_host_turn_end(end, "host_turn_failed")
+
+    with pytest.raises(SessionLifecycleError, match="conflicts"):
+        store.record_host_turn_end(end, "host_turn_completed_without_post")
+    assert store.ledger.rows()[-1]["terminal_reason"] == "host_turn_failed"
+
+
+def test_child_stop_first_and_session_end_later_share_one_terminal(tmp_path) -> None:
+    store = open_child_store(tmp_path)
+
+    child = store.record_host_child_stop(
+        "session-1", "host_turn_interrupted", NOW + timedelta(seconds=1)
+    )
+    replay = store.record_host_child_stop(
+        "session-1", "host_turn_interrupted", NOW + timedelta(seconds=2)
+    )
+    end = store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=ALL_HOOKS,
+        ),
+        "host_turn_interrupted",
+    )
+
+    assert child.hook == "subagent_stop"
+    assert replay.deduplicated is True
+    assert end.hook == "on_session_end"
+    assert end.snapshot.open_turn_id is None
+    terminal_rows = [
+        row for row in store.ledger.rows() if row["kind"] == "turn_terminal"
+    ]
+    assert len(terminal_rows) == 1
+    assert terminal_rows[0]["schema_version"] == SESSION_TURN_TERMINAL_SCHEMA
+    assert terminal_rows[0]["session_id"] == "session-1"
+    assert terminal_rows[0]["lifecycle_id"] == "lifecycle-1"
+    assert terminal_rows[0]["turn_id"] == "turn-1"
+    assert terminal_rows[0]["outcome"] == "abandoned"
+    assert terminal_rows[0]["reason"] == "host_turn_interrupted"
+    assert terminal_rows[0]["observed_at"] == "2026-08-24T19:00:01Z"
+
+
+def test_session_end_first_and_child_stop_later_add_one_callback(tmp_path) -> None:
+    store = open_child_store(tmp_path)
+    end = store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=ALL_HOOKS,
+        ),
+        "host_turn_failed",
+    )
+
+    child = store.record_host_child_stop("session-1", "host_turn_failed")
+    replay = store.record_host_child_stop("session-1", "host_turn_failed")
+
+    assert end.hook == "on_session_end"
+    assert child.hook == "subagent_stop"
+    assert replay.deduplicated is True
+    assert [row["kind"] for row in store.ledger.rows()].count("turn_terminal") == 1
+    assert [
+        row["hook"]
+        for row in store.ledger.rows()
+        if row["kind"] == "hook" and row["hook"] == "subagent_stop"
+    ] == ["subagent_stop"]
+
+
+def test_child_stop_after_finalized_terminal_is_idempotent(tmp_path) -> None:
+    store = open_child_store(tmp_path)
+    store.record_host_turn_end(
+        context(
+            "end",
+            source_kind="system",
+            turn_id="turn-1",
+            supported_hooks=ALL_HOOKS,
+        ),
+        "host_turn_failed",
+    )
+    store.record_hook(
+        context("finalize", source_kind="system", supported_hooks=ALL_HOOKS),
+        "on_session_finalize",
+    )
+    rows_before = store.ledger.rows()
+
+    receipt = store.record_host_child_stop("session-1", "host_turn_failed")
+
+    assert isinstance(receipt, SessionTurnTerminalReceipt)
+    assert receipt.deduplicated is True
+    assert store.ledger.rows() == rows_before
+
+
+def test_child_stop_closes_legacy_lifecycle_without_rewriting_hooks(tmp_path) -> None:
+    supported = frozenset(HOOK_ORDER[:-1])
+    store = open_child_store(tmp_path, supported)
+
+    first = store.record_host_child_stop("session-1", "host_turn_failed")
+    replay = store.record_host_child_stop("session-1", "host_turn_failed")
+
+    assert first.deduplicated is False
+    assert first.reason == "host_turn_failed"
+    assert replay.deduplicated is True
+    assert first.snapshot.supported_hooks == supported
+    assert "subagent_stop" not in first.snapshot.hooks
+    assert [row["kind"] for row in store.ledger.rows()] == [
+        "hook",
+        "hook",
+        "hook",
+        "turn_terminal",
+    ]
+
+
+def test_child_stop_rejects_ambiguous_identity_and_conflicting_reason(tmp_path) -> None:
+    supported = frozenset({"pre_llm_call"})
+    store = SessionLifecycleStore(tmp_path)
+    store.record_hook(
+        context(
+            "pre-a", lifecycle_id="life-a", turn_id="turn-a", supported_hooks=supported
+        ),
+        "pre_llm_call",
+    )
+    store.record_hook(
+        context(
+            "pre-b", lifecycle_id="life-b", turn_id="turn-b", supported_hooks=supported
+        ),
+        "pre_llm_call",
+    )
+
+    with pytest.raises(SessionLifecycleError, match="multiple Moonbite"):
+        store.record_host_child_stop("session-1", "host_turn_failed")
+
+    store = open_child_store(tmp_path / "conflict")
+    store.record_host_child_stop("session-1", "host_turn_failed")
+    with pytest.raises(SessionLifecycleError, match="conflicts"):
+        store.record_host_child_stop("session-1", "host_turn_interrupted")
+
+
+def test_late_post_cannot_replace_child_stop_terminal(tmp_path) -> None:
+    store = open_child_store(tmp_path)
+    store.record_host_child_stop("session-1", "host_turn_interrupted")
+
+    with pytest.raises(SessionLifecycleError, match="already terminal"):
+        store.record_hook(
+            context(
+                "post",
+                source_kind="assistant_response",
+                turn_id="turn-1",
+                fresh=False,
+                supported_hooks=ALL_HOOKS,
+            ),
+            "post_llm_call",
+            settled=True,
+        )
 
 
 def test_multiple_turns_require_settled_previous_turn(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- normalize Hermes on_session_end into canonical terminal evidence without treating a missing post callback as active chat
- add a bounded subagent_stop fallback for failed, interrupted, errored, or timed-out one-shot children
- preserve terminal vs settled semantics, append-only first-terminal-wins behavior, compression rotation correlation, and legacy lifecycle replay
- require the canonical terminal ports at the injected session-owner boundary

## Compatibility

- required CLI/Gateway lanes: Hermes v0.20.5 at fcbd1076 and v0.21.0 at 29112be
- both lanes register 10 tools and 7 hooks
- Hermes Desktop remains out of scope

## Verification

- 795 tests passed
- compileall, Ruff check, targeted format check, and diff check passed
- contract, clean install, and clean wheel passed on both required Hermes lanes
- repository/history and unpacked wheel/sdist privacy scans passed

Fixes #14